### PR TITLE
Typo fix

### DIFF
--- a/KrbRelayUp/Program.cs
+++ b/KrbRelayUp/Program.cs
@@ -34,7 +34,7 @@ namespace KrbRelayUp
         public static void GetHelp()
         {
             Console.WriteLine("RELAY:");
-            Console.WriteLine("Usage: KrbRelayUp.exe relay -d FQDN -cn CUMPUTERNAME [-c] [-cp PASSWORD | -ch NTHASH]\n");
+            Console.WriteLine("Usage: KrbRelayUp.exe relay -d FQDN -cn COMPUTERNAME [-c] [-cp PASSWORD | -ch NTHASH]\n");
             Console.WriteLine("    -d  (--Domain)                   FQDN of domain.");
             Console.WriteLine("    -c  (--CreateNewComputerAccount)    Create new computer account for RBCD. Will use the current authenticated user.");
             Console.WriteLine("    -cn (--ComputerName)             Name of attacker owned computer account for RBCD. (deafult=KRBRELAYUP$ [if -c is enabled])");

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Simple wrapper around some of the features of [Rubeus](https://github.com/GhostP
 KrbRelayUp - Relaying you to SYSTEM
 
 RELAY:
-Usage: KrbRelayUp.exe relay -d FQDN -cn CUMPUTERNAME [-c] [-cp PASSWORD | -ch NTHASH]
+Usage: KrbRelayUp.exe relay -d FQDN -cn COMPUTERNAME [-c] [-cp PASSWORD | -ch NTHASH]
 
     -d  (--Domain)                   FQDN of domain.
     -c  (--CreateNewComputerAccount)    Create new computer account for RBCD. Will use the current authenticated user.


### PR DESCRIPTION
Small but funny typo fixed `CUMPUTER` -> `COMPUTER`