### PR TITLE
Minor fix for the caEndpoint option

### DIFF
--- a/KrbRelayUp/Program.cs
+++ b/KrbRelayUp/Program.cs
@@ -207,7 +207,9 @@ namespace KrbRelayUp
             {
                 try
                 {
-                    Options.caEndpoint = new Uri(Options.caEndpoint).Host;
+                    //Options.caEndpoint = new Uri(Options.caEndpoint).Host; <- This somewhat messed with the execuutionflow when a users enters httpx://server.domain.bla/bla
+                    //new method with regex insted of Uri.host method
+                    Options.caEndpoint = Regex.Replace(Options.caEndpoint, @"^([a-zA-Z]+:\/\/)?([^\/]+)\/.*?$", "$2");
                 }
                 catch { }
             }


### PR DESCRIPTION
Changed from Uri.Host method to regex for when a user enters a complete URI instead of just the FQDN of the CA.