### PR TITLE
Fix LDAP binding

### DIFF
--- a/KrbRelayUp/Relay/Ldap.cs
+++ b/KrbRelayUp/Relay/Ldap.cs
@@ -46,7 +46,7 @@ namespace KrbRelayUp.Relay
                 ldap_unbind(ld);
                 //Environment.Exit(0);
             }
-            if ((LdapStatus)value != LdapStatus.LDAP_SASL_BIND_IN_PROGRESS)
+            else if ((LdapStatus)value != LdapStatus.LDAP_SASL_BIND_IN_PROGRESS)
             {
                 if (!Options.attackDone)
                     Console.WriteLine("[-] LDAP connection failed");


### PR DESCRIPTION
Hey @Dec0ne, thanks for this awesome tool!

I've noticed that on some versions of Windows (Servers 2012 R2 / 2016) highlighted IF statement is causing LDAP binding troubles due to `LDAP_SASL_BIND_IN_PROGRESS`.

UPD. Nope, additional tests showed that's not the case, closing this one.