### PR TITLE
Switch to UTF-8 encoding for LDAP

### DIFF
--- a/KrbRelayUp/Relay/Attacks/Generic.cs
+++ b/KrbRelayUp/Relay/Attacks/Generic.cs
@@ -199,7 +199,7 @@ namespace KrbRelayUp.Relay.Attacks.Ldap
             //Console.WriteLine("[+] {0}: {1}", attribute, Encoding.ASCII.GetString(t));
 
             Marshal.FreeHGlobal(controlPtr);
-            return Encoding.ASCII.GetString(t);
+            return Encoding.UTF8.GetString(t);
             //return "";
         }
 
@@ -246,7 +246,7 @@ namespace KrbRelayUp.Relay.Attacks.Ldap
             //Console.WriteLine("[+] {0}: {1}", attribute, Encoding.ASCII.GetString(t));
 
             Marshal.FreeHGlobal(controlPtr);
-            return Encoding.ASCII.GetString(t);
+            return Encoding.UTF8.GetString(t);
         }
     }
 }


### PR DESCRIPTION
Finally figured out what caused the issue raised in #25.

Switched to UTF-8 encoding for LDAP requests in this PR. It can potentially help non-native English AD exploitation.